### PR TITLE
Replace lookupdev with findalldevs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
  - [doc](https://docs.rs/pcap/latest/pcap/) will now include all features
 
+### Changed
+
+- `Device::lookup` now returns `Result<Option<Device>, Error>` rather than `Result<Device, Error>`. `Ok(None)` means that the lookup succeeded, but no suitable devices were available. This is consistent with libpcap.
+
 ### Removed
 
 - `docs-rs` feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ futures = { version = "0.3", optional = true }
 errno = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-widestring = "0.2"
-winapi = {version = "0.3", features = ["ws2def", "ws2ipdef"]} 
+winapi = {version = "0.3", features = ["ws2def", "ws2ipdef"]}
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/examples/easylisten.rs
+++ b/examples/easylisten.rs
@@ -1,6 +1,8 @@
 fn main() {
     // get the default Device
-    let device = pcap::Device::lookup().unwrap();
+    let device = pcap::Device::lookup()
+        .expect("device lookup failed")
+        .expect("no device available");
     println!("Using device {}", device.name);
 
     // Setup Capture

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -1,6 +1,6 @@
 fn main() {
     // list all of the devices pcap tells us are available
-    for device in pcap::Device::list().unwrap() {
+    for device in pcap::Device::list().expect("device lookup failed") {
         println!("Found device! {:?}", device);
 
         // now you can create a Capture with this Device if you want.

--- a/examples/getstatistics.rs
+++ b/examples/getstatistics.rs
@@ -1,6 +1,8 @@
 fn main() {
     // get the default Device
-    let device = pcap::Device::lookup().unwrap();
+    let device = pcap::Device::lookup()
+        .expect("device lookup failed")
+        .expect("no device available");
     println!("Using device {}", device.name);
 
     // Setup Capture

--- a/examples/savefile.rs
+++ b/examples/savefile.rs
@@ -3,7 +3,9 @@ use pcap::*;
 fn main() {
     {
         // open capture from default device
-        let device = Device::lookup().unwrap();
+        let device = Device::lookup()
+            .expect("device lookup failed")
+            .expect("no device available");
         println!("Using device {}", device.name);
 
         // Setup Capture

--- a/examples/streamecho.rs
+++ b/examples/streamecho.rs
@@ -19,9 +19,8 @@ impl PacketCodec for BoxCodec {
     }
 }
 
-fn new_stream() -> Result<PacketStream<Active, BoxCodec>, Error> {
+fn new_stream(device: Device) -> Result<PacketStream<Active, BoxCodec>, Error> {
     // get the default Device
-    let device = Device::lookup()?;
     println!("Using device {}", device.name);
 
     let cap = Capture::from_device(device)?
@@ -33,7 +32,8 @@ fn new_stream() -> Result<PacketStream<Active, BoxCodec>, Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn error::Error>> {
-    let mut stream = new_stream()?;
+    let device = Device::lookup()?.ok_or("no device available")?;
+    let mut stream = new_stream(device)?;
 
     loop {
         // Here in the event loop we may await a bunch of other

--- a/examples/streamlisten.rs
+++ b/examples/streamlisten.rs
@@ -16,8 +16,8 @@ impl PacketCodec for SimpleDumpCodec {
     }
 }
 
-async fn start_new_stream() -> PacketStream<Active, SimpleDumpCodec> {
-    match new_stream() {
+async fn start_new_stream(device: Device) -> PacketStream<Active, SimpleDumpCodec> {
+    match new_stream(device) {
         Ok(stream) => stream,
         Err(e) => {
             println!("{:?}", e);
@@ -26,9 +26,8 @@ async fn start_new_stream() -> PacketStream<Active, SimpleDumpCodec> {
     }
 }
 
-fn new_stream() -> Result<PacketStream<Active, SimpleDumpCodec>, Error> {
+fn new_stream(device: Device) -> Result<PacketStream<Active, SimpleDumpCodec>, Error> {
     // get the default Device
-    let device = Device::lookup()?;
     println!("Using device {}", device.name);
 
     let cap = Capture::from_device(device)?
@@ -44,7 +43,10 @@ fn main() {
         .build()
         .unwrap();
 
-    let stream = rt.block_on(start_new_stream());
+    let device = Device::lookup()
+        .expect("device lookup failed")
+        .expect("no device available");
+    let stream = rt.block_on(start_new_stream(device));
 
     let fut = stream.for_each(move |s| {
         println!("{:?}", s);

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -81,7 +81,7 @@ pub type pcap_handler =
     Option<extern "C" fn(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar) -> ()>;
 
 extern "C" {
-    pub fn pcap_lookupdev(arg1: *mut c_char) -> *mut c_char;
+    // [OBSOLETE] pub fn pcap_lookupdev(arg1: *mut c_char) -> *mut c_char;
     // pub fn pcap_lookupnet(arg1: *const c_char, arg2: *mut c_uint, arg3: *mut c_uint,
     //                       arg4: *mut c_char) -> c_int;
     pub fn pcap_create(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t;


### PR DESCRIPTION
Turns out there's already an example of using `findalldevs` in `pcap`. It was in the function below `list`. 

However, by removing `lookupdev` I realised that the case of no default device was not handled at all. I've currently handled this by returning a `Results<Option<Device>, Error>` as opposed to a `Result<Device, Error>`.

A possible alternative would be to translate the null option to an error, but that would be semantically different from what [libpcap does](https://www.tcpdump.org/manpages/pcap_findalldevs.3pcap.html) which does not consider the null case to be an error.

Currently a draft PR, because I want to have a think if there's a slightly prettier solution.

Closes #158