### PR TITLE
Tidy up the stream module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,11 @@ path = "examples/streamlisten_mt.rs"
 required-features = ["capture-stream"]
 
 [[example]]
+name = "streamecho"
+path = "examples/streamecho.rs"
+required-features = ["capture-stream"]
+
+[[example]]
 name = "nfbpfcompile"
 path = "examples/nfbpfcompile.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ build = "build.rs"
 [dependencies]
 libc = "0.2"
 clippy = { version = "0.0.*", optional = true }
-mio = { version = "0.6", optional = true }
 tokio = { version = "1.0", features = ["net", "rt", "macros", "rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }
 errno = "0.2"
@@ -34,8 +33,8 @@ regex = "1"
 
 [features]
 # This feature enables access to the function Capture::stream.
-# This is disabled by default, because it depends on a tokio and mio
-capture-stream = ["mio", "tokio", "futures"]
+# This is disabled by default, because it depends on a tokio
+capture-stream = ["tokio", "futures"]
 
 # A shortcut to enable all features.
 full = ["capture-stream"]

--- a/examples/streamecho.rs
+++ b/examples/streamecho.rs
@@ -1,0 +1,44 @@
+//! Example of using streams for an echo server.
+//!
+//! For brewity replies are sent with the same headers as the incoming
+//! packets.
+use futures::StreamExt;
+use pcap::stream::{PacketCodec, PacketStream};
+use pcap::{Active, Capture, Device, Error, Packet};
+use std::error;
+
+// Simple codec that returns owned copies, since the result may not
+// reference the input packet.
+pub struct BoxCodec;
+
+impl PacketCodec for BoxCodec {
+    type Type = Box<[u8]>;
+
+    fn decode(&mut self, packet: Packet) -> Result<Self::Type, Error> {
+        Ok(packet.data.into())
+    }
+}
+
+fn new_stream() -> Result<PacketStream<Active, BoxCodec>, Error> {
+    // get the default Device
+    let device = Device::lookup()?;
+    println!("Using device {}", device.name);
+
+    let cap = Capture::from_device(device)?
+        .immediate_mode(true)
+        .open()?
+        .setnonblock()?;
+    cap.stream(BoxCodec)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error>> {
+    let mut stream = new_stream()?;
+
+    loop {
+        // Here in the event loop we may await a bunch of other
+        // futures too, using the select! macro from tokio.
+        let data = stream.next().await.unwrap()?;
+        stream.inner_mut().sendpacket(data)?;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,13 +63,9 @@
 
 use unique::Unique;
 
-#[cfg(feature = "capture-stream")]
-use core::task::Poll::Ready;
 use std::borrow::Borrow;
 use std::ffi::{self, CStr, CString};
 use std::fmt;
-#[cfg(feature = "capture-stream")]
-use std::io;
 use std::marker::PhantomData;
 use std::mem;
 use std::net::IpAddr;
@@ -1093,40 +1089,7 @@ impl<T: Activated + ?Sized> Capture<T> {
         }
     }
 
-    #[cfg(feature = "capture-stream")]
-    fn next_noblock<'a>(
-        &'a mut self,
-        cx: &mut core::task::Context,
-        fd: &mut tokio::io::unix::AsyncFd<stream::SelectableFd>,
-    ) -> Result<Packet<'a>, Error> {
-        let ready = fd.poll_read_ready(cx);
-        if ready.is_pending() {
-            Err(IoError(io::ErrorKind::WouldBlock))
-        } else {
-            match self.next() {
-                Ok(p) => Ok(p),
-                Err(TimeoutExpired) => {
-                    // Per https://docs.rs/tokio/1.12.0/tokio/io/unix/struct.AsyncFd.html
-                    // ... it is critical to ensure that this ready flag
-                    // is cleared when (and only when) the file descriptor
-                    // ceases to be ready.
-                    //
-                    if let Ready(Ok(mut guard)) = ready {
-                        guard.clear_ready();
-                        #[allow(unused_must_use)]
-                        {
-                            fd.poll_read_ready(cx);
-                        }
-                    }
-
-                    Err(IoError(io::ErrorKind::WouldBlock))
-                }
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    #[cfg(feature = "capture-stream")]
+    #[cfg(all(unix, feature = "capture-stream"))]
     pub fn stream<C: stream::PacketCodec>(
         self,
         codec: C,
@@ -1134,10 +1097,7 @@ impl<T: Activated + ?Sized> Capture<T> {
         if !self.nonblock {
             return Err(NonNonBlock);
         }
-        unsafe {
-            let fd = raw::pcap_get_selectable_fd(*self.handle);
-            stream::PacketStream::new(self, fd, codec)
-        }
+        stream::PacketStream::new(SelectableCapture(self), codec)
     }
 
     /// Adds a filter to the capture using the given BPF program string. Internally
@@ -1230,17 +1190,28 @@ impl Capture<Dead> {
 
 #[cfg(not(windows))]
 impl AsRawFd for Capture<Active> {
+    /// Returns the file descriptor for a live capture.
     fn as_raw_fd(&self) -> RawFd {
-        unsafe {
-            let fd = raw::pcap_fileno(*self.handle);
+        let fd = unsafe { raw::pcap_fileno(*self.handle) };
+        assert!(fd != -1, "Unable to get file descriptor for live capture");
+        fd
+    }
+}
 
-            match fd {
-                -1 => {
-                    panic!("Unable to get file descriptor for live capture");
-                }
-                fd => fd,
-            }
-        }
+/// Newtype [`Capture`] wrapper that exposes `pcap_get_selectable_fd()`.
+struct SelectableCapture<T: State + ?Sized>(Capture<T>);
+
+#[cfg(unix)]
+impl<T: Activated + ?Sized> AsRawFd for SelectableCapture<T> {
+    /// Returns the file descriptor for a live capture.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the network device does not support `select()`.
+    fn as_raw_fd(&self) -> RawFd {
+        let fd = unsafe { raw::pcap_get_selectable_fd(*self.0.handle) };
+        assert!(fd != -1, "Unable to get file descriptor for live capture");
+        fd
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,94 +1,63 @@
+//! Support for asynchronous packet iteration.
 use super::Activated;
 use super::Capture;
 use super::Error;
 use super::Packet;
-use super::State;
-use mio::event::Evented;
-use mio::unix::EventedFd;
-use mio::{Poll, PollOpt, Ready, Token};
+use super::SelectableCapture;
+use futures::ready;
 use std::io;
 use std::marker::Unpin;
-#[cfg(not(windows))]
-use std::os::unix::io::RawFd;
 use std::pin::Pin;
-
-pub struct SelectableFd {
-    fd: RawFd,
-}
-
-impl Evented for SelectableFd {
-    fn register(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.fd).register(poll, token, interest, opts)
-    }
-
-    fn reregister(
-        &self,
-        poll: &Poll,
-        token: Token,
-        interest: Ready,
-        opts: PollOpt,
-    ) -> io::Result<()> {
-        EventedFd(&self.fd).reregister(poll, token, interest, opts)
-    }
-
-    fn deregister(&self, poll: &Poll) -> io::Result<()> {
-        EventedFd(&self.fd).deregister(poll)
-    }
-}
-
-impl std::os::unix::io::AsRawFd for SelectableFd {
-    fn as_raw_fd(&self) -> RawFd {
-        self.fd
-    }
-}
+use std::task::{self, Poll};
+use tokio::io::unix::AsyncFd;
 
 pub trait PacketCodec {
     type Type;
     fn decode(&mut self, packet: Packet) -> Result<Self::Type, Error>;
 }
 
-pub struct PacketStream<T: State + ?Sized, C> {
-    cap: Capture<T>,
-    fd: tokio::io::unix::AsyncFd<SelectableFd>,
+pub struct PacketStream<T: Activated + ?Sized, C> {
+    inner: AsyncFd<SelectableCapture<T>>,
     codec: C,
 }
 
-impl<T: Activated + ?Sized, C: PacketCodec> PacketStream<T, C> {
-    pub fn new(cap: Capture<T>, fd: RawFd, codec: C) -> Result<PacketStream<T, C>, Error> {
+impl<T: Activated + ?Sized, C> PacketStream<T, C> {
+    pub(crate) fn new(capture: SelectableCapture<T>, codec: C) -> Result<Self, Error> {
         Ok(PacketStream {
-            cap,
-            fd: tokio::io::unix::AsyncFd::with_interest(
-                SelectableFd { fd },
-                tokio::io::Interest::READABLE,
-            )?,
+            inner: AsyncFd::with_interest(capture, tokio::io::Interest::READABLE)?,
             codec,
         })
     }
+
+    /// Returns a mutable reference to the inner [`Capture`].
+    ///
+    /// The caller must ensure the capture will not be set to be
+    /// blocking.
+    pub fn inner_mut(&mut self) -> &mut Capture<T> {
+        &mut self.inner.get_mut().0
+    }
 }
 
-impl<'a, T: Activated + ?Sized + Unpin, C: PacketCodec + Unpin> futures::Stream
-    for PacketStream<T, C>
-{
+impl<T: Activated + ?Sized, C> Unpin for PacketStream<T, C> {}
+
+impl<T: Activated + ?Sized, C: PacketCodec> futures::Stream for PacketStream<T, C> {
     type Item = Result<C::Type, Error>;
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut core::task::Context,
-    ) -> futures::task::Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
         let stream = Pin::into_inner(self);
-        let p = match stream.cap.next_noblock(cx, &mut stream.fd) {
-            Ok(t) => t,
-            Err(Error::IoError(ref e)) if *e == ::std::io::ErrorKind::WouldBlock => {
-                return futures::task::Poll::Pending;
+        let codec = &mut stream.codec;
+        loop {
+            let mut guard = ready!(stream.inner.poll_read_ready_mut(cx))?;
+            match guard.try_io(|inner| match inner.get_mut().0.next() {
+                Ok(p) => Ok(Ok(codec.decode(p))),
+                Err(e @ Error::TimeoutExpired) => Err(io::Error::new(io::ErrorKind::WouldBlock, e)),
+                Err(e) => Ok(Err(e)),
+            }) {
+                Ok(result) => {
+                    let frame_result = result.unwrap()?;
+                    return Poll::Ready(Some(frame_result));
+                }
+                Err(_would_block) => continue,
             }
-            Err(e) => return futures::task::Poll::Ready(Some(Err(e))),
-        };
-        let frame_result = stream.codec.decode(p);
-        futures::task::Poll::Ready(Some(frame_result))
+        }
     }
 }


### PR DESCRIPTION
* Remove unused direct dependency on mio.
* Inline the `Capture::next_noblock` method into stream module.
* Use newtype wrapper of `Capture` that implements `AsRawFd` with
  `pcap_get_selectable_fd()`, instead of new data type `SelectableFd` that
  carries around the fd;
* ...in order to use `AsyncFdReadyMutGuard::try_io` which abstracts away
  the details previously explicit in `Capture::next_noblock`.
* (Drop the `PacketCodec` requirement of being `Unpin`.)
* Add `PacketStream::inner_mut` to make it possible to inject packets
  in-between awaiting packets.

This is a breaking change since it removes `stream::SelectableFd` and
`stream::PacketStream::new` from the public API.

Closes #192