### PR TITLE
change `PacketStream` codec to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### Added
 
  - [doc](https://docs.rs/pcap/latest/pcap/) will now include all features
-
 ### Changed
 
 - `Device::lookup` now returns `Result<Option<Device>, Error>` rather than `Result<Device, Error>`. `Ok(None)` means that the lookup succeeded, but no suitable devices were available. This is consistent with libpcap.
+- `PacketStream`'s `codec` is now public.
 
 ### Removed
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -20,7 +20,7 @@ pub trait PacketCodec {
 
 pub struct PacketStream<T: Activated + ?Sized, C> {
     inner: AsyncFd<SelectableCapture<T>>,
-    codec: C,
+    pub codec: C,
 }
 
 impl<T: Activated + ?Sized, C> PacketStream<T, C> {


### PR DESCRIPTION
Hi,
I have a use case where I'm using `PacketStream` but I want to access the underlying codec which is moved into it.
I guess there are two options - make it public or make a `inner_mut` method for it. I thought making it public would be easier as it's a "user" given struct and implementation, which means that they accessing it directly shouldn't cause any issues.
Let me know if there's a better approach here.
