### PR TITLE
Implement iterator & Change to stream & Utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.toolchain == 'stable'
         run: cargo clippy ${{ matrix.profile }} ${{ matrix.features }} -- -D warnings
       - name: cargo doc
-        run: env DOCS_RS=true cargo doc ${{ matrix.profile }} ${{ matrix.features }}
+        run: env DOCS_RS=true cargo doc ${{ matrix.profile }} ${{ matrix.features }} --no-deps
       - name: cargo fmt
         if: matrix.toolchain == 'stable'
         run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.40.0", "1.46.0", stable, beta]
+        toolchain: ["1.41.0", "1.46.0", stable, beta]
         profile: ['', --release]
         features: ['', '--all-features']
         exclude:
@@ -26,13 +26,13 @@ jobs:
           - os: windows-latest
             features: '--all-features'
           - os: windows-latest
-            toolchain: "1.40.0"
+            toolchain: "1.41.0"
           # 1.46.0 is only a special requirement on Windows
           - os: ubuntu-latest
             toolchain: "1.46.0"
           - os: macos-latest
             toolchain: "1.46.0"
-          - toolchain: "1.40.0"
+          - toolchain: "1.41.0"
             features: '--all-features'
         include:
           # nightly check is performed on ubuntu only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
+- MSRV is now `1.41.0`
 - `PacketStream` have been moved from mod `stream` to the `root` of the crate
 - `PacketCodec` have been moved from mod `stream` to the `root` of the crate
 - `PacketCodec::decode()` no longer return a `Result`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [doc](https://docs.rs/pcap/latest/pcap/) will now include all features
 - Add support for sendqueues on Windows.
-- Add `PacketStream::inner_mut` to still be able to inject packets when using `PacketStream`
+- Add `PacketStream::capture_mut` to still be able to inject packets when using `PacketStream`
 - `Capture::iter()` that return an iterator that use a codec like `Capture::stream()`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,24 @@
 
 ### Added
 
- - [doc](https://docs.rs/pcap/latest/pcap/) will now include all features
- - Add support for sendqueues on Windows.
- - Add `PacketStream::inner_mut` to still be able to inject packets when using `PacketStream`
+- [doc](https://docs.rs/pcap/latest/pcap/) will now include all features
+- Add support for sendqueues on Windows.
+- Add `PacketStream::inner_mut` to still be able to inject packets when using `PacketStream`
+- `Capture::iter()` that return an iterator that use a codec like `Capture::stream()`
 
 ### Changed
 
+- `PacketStream` have been moved from mod `stream` to the `root` of the crate
+- `PacketCodec` have been moved from mod `stream` to the `root` of the crate
+- `PacketCodec::decode()` no longer return a `Result`
+- `PacketCodec::Type` have been renamed `PacketCodec::Item`
 - `Device::lookup` now returns `Result<Option<Device>, Error>` rather than `Result<Device, Error>`. `Ok(None)` means that the lookup succeeded, but no suitable devices were available. This is consistent with libpcap.
 - `Capture` and `Savefile` no longer implement the `Sync` trait. The underlying `libpcap` library does not promise thread-safe access for the same capture object from multiple threads.
 - Switched from `winapi` to `windows-sys` for Windows builds.  `windows-sys` requires rustc 1.46.0.
 
 ### Removed
 
+- mod `stream` is no longer public
 - `docs-rs` feature
 - `full` feature
 - `stream::SelectableFd` and `stream::PacketStream::new` as they were only meant to be used internally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - `PacketCodec::Type` have been renamed `PacketCodec::Item`
 - `Device::lookup` now returns `Result<Option<Device>, Error>` rather than `Result<Device, Error>`. `Ok(None)` means that the lookup succeeded, but no suitable devices were available. This is consistent with libpcap.
 - `Capture` and `Savefile` no longer implement the `Sync` trait. The underlying `libpcap` library does not promise thread-safe access for the same capture object from multiple threads.
-- Switched from `winapi` to `windows-sys` for Windows builds.  `windows-sys` requires rustc 1.46.0.
+- Switched from `winapi` to `windows-sys` for Windows builds. `windows-sys` requires rustc 1.46.0.
+- `Capture::next` have been rename `next_packet` to avoid any confusion with `Iterator::next`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See examples for usage.
 
 # Building
 
-As of 0.8.0 this crate uses Rust 2018 and requires a compiler version >= 1.40.0.
+As of 0.8.0 this crate uses Rust 2018 and requires a compiler version >= 1.41.0.
 
 The feature `capture-stream` depends on `tokio`, but we only lock `tokio` version to `1.0`. Therefore, when `capture-stream` is enabled, this crate requires a compiler version new enough to compile the `tokio` crate.
 
@@ -53,6 +53,10 @@ If `LIBPCAP_LIBDIR` environment variable is set when building the crate, it will
 ## Library Version
 
 The crate will automatically try to detect the installed `libpcap`/`wpcap` version by loading it during the build and calling `pcap_lib_version`. If for some reason this is not suitable, you can specify the desired library version by setting the environment variable `LIBPCAP_VER` to the desired version (e.g. `env LIBPCAP_VER=1.5.0`). The version number is used to determine which library calls to include in the compilation.
+
+## Minimum Supported Rust Version (MSRV)
+
+Talk about policies about MSRV is on [#240](https://github.com/rust-pcap/pcap/discussions/240)
 
 ## Optional Features
 

--- a/examples/easylisten.rs
+++ b/examples/easylisten.rs
@@ -13,5 +13,5 @@ fn main() {
         .unwrap();
 
     // get a packet and print its bytes
-    println!("{:?}", cap.next());
+    println!("{:?}", cap.next_packet());
 }

--- a/examples/getstatistics.rs
+++ b/examples/getstatistics.rs
@@ -14,7 +14,7 @@ fn main() {
 
     // get 10 packets
     for _ in 0..10 {
-        cap.next().ok();
+        cap.next_packet().ok();
     }
     let stats = cap.stats().unwrap();
     println!(

--- a/examples/iter_print.rs
+++ b/examples/iter_print.rs
@@ -1,0 +1,41 @@
+//! Example of using iterators that print paquet
+use pcap::{Capture, Device, Packet, PacketCodec, PacketHeader};
+use std::error;
+
+/// Represents a owned packet
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PacketOwned {
+    pub header: PacketHeader,
+    pub data: Box<[u8]>,
+}
+
+/// Simple codec that tranform [`pcap::Packet`] into [`PacketOwned`]
+pub struct Codec;
+
+impl PacketCodec for Codec {
+    type Item = PacketOwned;
+
+    fn decode(&mut self, packet: Packet) -> Self::Item {
+        PacketOwned {
+            header: *packet.header,
+            data: packet.data.into(),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn error::Error>> {
+    let device = Device::lookup()?.ok_or("no device available")?;
+
+    // get the default Device
+    println!("Using device {}", device.name);
+
+    let cap = Capture::from_device(device)?.immediate_mode(true).open()?;
+
+    for packet in cap.iter(Codec) {
+        let packet = packet?;
+
+        println!("{:?}", packet);
+    }
+
+    Ok(())
+}

--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -10,7 +10,7 @@ fn main() {
     // filter out all packets that don't have 127.0.0.1 as a source or destination.
     cap.filter("host 127.0.0.1", true).unwrap();
 
-    while let Ok(packet) = cap.next() {
+    while let Ok(packet) = cap.next_packet() {
         println!("got packet! {:?}", packet);
     }
 }

--- a/examples/nfbpfcompile.rs
+++ b/examples/nfbpfcompile.rs
@@ -12,7 +12,7 @@ fn main() {
         2 => ("RAW".to_string(), env::args().nth(1).unwrap()),
         3 => (env::args().nth(1).unwrap(), env::args().nth(2).unwrap()),
         _ => {
-            println!("Usage:    {} [type] 'program'", env::args().nth(0).unwrap());
+            println!("Usage:    {} [type] 'program'", env::args().next().unwrap());
             println!("  type: a pcap linklayer type, e.g:");
             println!("      RAW, EN10MB");
             println!("  program: a pcap filter expression e.g.:");

--- a/examples/savefile.rs
+++ b/examples/savefile.rs
@@ -19,7 +19,7 @@ fn main() {
         let mut savefile = cap.savefile("test.pcap").unwrap();
 
         // get a packet from the interface
-        let p = cap.next().unwrap();
+        let p = cap.next_packet().unwrap();
 
         // print the packet out
         println!("packet received on network: {:?}", p);
@@ -32,7 +32,7 @@ fn main() {
     let mut cap = Capture::from_file("test.pcap").unwrap();
 
     // get a packet
-    let p = cap.next().unwrap();
+    let p = cap.next_packet().unwrap();
 
     // print that packet out -- it should be the same as the one we printed above
     println!("packet obtained from file: {:?}", p);

--- a/examples/streamecho.rs
+++ b/examples/streamecho.rs
@@ -3,8 +3,7 @@
 //! For brewity replies are sent with the same headers as the incoming
 //! packets.
 use futures::StreamExt;
-use pcap::stream::{PacketCodec, PacketStream};
-use pcap::{Active, Capture, Device, Error, Packet};
+use pcap::{Active, Capture, Device, Error, Packet, PacketCodec, PacketStream};
 use std::error;
 
 // Simple codec that returns owned copies, since the result may not
@@ -12,10 +11,10 @@ use std::error;
 pub struct BoxCodec;
 
 impl PacketCodec for BoxCodec {
-    type Type = Box<[u8]>;
+    type Item = Box<[u8]>;
 
-    fn decode(&mut self, packet: Packet) -> Result<Self::Type, Error> {
-        Ok(packet.data.into())
+    fn decode(&mut self, packet: Packet) -> Self::Item {
+        packet.data.into()
     }
 }
 

--- a/examples/streamecho.rs
+++ b/examples/streamecho.rs
@@ -38,6 +38,6 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
         // Here in the event loop we may await a bunch of other
         // futures too, using the select! macro from tokio.
         let data = stream.next().await.unwrap()?;
-        stream.inner_mut().sendpacket(data)?;
+        stream.capture_mut().sendpacket(data)?;
     }
 }

--- a/examples/streamlisten.rs
+++ b/examples/streamlisten.rs
@@ -3,16 +3,15 @@
 // and multiple threads.
 //
 use futures::StreamExt;
-use pcap::stream::{PacketCodec, PacketStream};
-use pcap::{Active, Capture, Device, Error, Packet};
+use pcap::{Active, Capture, Device, Error, Packet, PacketCodec, PacketStream};
 
 pub struct SimpleDumpCodec;
 
 impl PacketCodec for SimpleDumpCodec {
-    type Type = String;
+    type Item = String;
 
-    fn decode(&mut self, packet: Packet) -> Result<Self::Type, Error> {
-        Ok(format!("{:?}", packet))
+    fn decode(&mut self, packet: Packet) -> Self::Item {
+        format!("{:?}", packet)
     }
 }
 

--- a/examples/streamlisten_mt.rs
+++ b/examples/streamlisten_mt.rs
@@ -1,15 +1,14 @@
 use futures::StreamExt;
-use pcap::stream::{PacketCodec, PacketStream};
-use pcap::{Active, Capture, Device, Error, Packet};
+use pcap::{Active, Capture, Device, Error, Packet, PacketCodec, PacketStream};
 use std::error;
 
 pub struct SimpleDumpCodec;
 
 impl PacketCodec for SimpleDumpCodec {
-    type Type = String;
+    type Item = String;
 
-    fn decode(&mut self, packet: Packet) -> Result<Self::Type, Error> {
-        Ok(format!("{:?}", packet))
+    fn decode(&mut self, packet: Packet) -> Self::Item {
+        format!("{:?}", packet)
     }
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,12 @@
+use crate::Packet;
+
+/// This trait is used to implement Stream and Iterator feature.
+/// This is almost like `map()`.
+///
+// This is needed cause we don't have GaTs
+// Once GaTs are stable we could use them to implement better Iterator
+pub trait PacketCodec {
+    type Item;
+
+    fn decode(&mut self, packet: Packet) -> Self::Item;
+}

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,0 +1,38 @@
+use crate::Activated;
+use crate::Capture;
+use crate::Error;
+use crate::PacketCodec;
+
+/// Implement an Iterator of Packet
+pub struct PacketIter<S: Activated + ?Sized, C> {
+    capture: Capture<S>,
+    codec: C,
+}
+
+impl<S: Activated + ?Sized, C> PacketIter<S, C> {
+    pub(crate) fn new(capture: Capture<S>, codec: C) -> Self {
+        Self { capture, codec }
+    }
+
+    pub fn capture_mut(&mut self) -> &mut Capture<S> {
+        &mut self.capture
+    }
+}
+
+impl<S: Activated + ?Sized, C> From<PacketIter<S, C>> for (Capture<S>, C) {
+    fn from(iter: PacketIter<S, C>) -> Self {
+        (iter.capture, iter.codec)
+    }
+}
+
+impl<S: Activated + ?Sized, C: PacketCodec> Iterator for PacketIter<S, C> {
+    type Item = Result<C::Item, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.capture.next() {
+            Ok(packet) => Some(Ok(self.codec.decode(packet))),
+            Err(Error::NoMorePackets) => None,
+            Err(e) => Some(Err(e)),
+        }
+    }
+}

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -14,6 +14,7 @@ impl<S: Activated + ?Sized, C> PacketIter<S, C> {
         Self { capture, codec }
     }
 
+    /// Returns a mutable reference to the inner [`Capture`].
     pub fn capture_mut(&mut self) -> &mut Capture<S> {
         &mut self.capture
     }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -29,7 +29,7 @@ impl<S: Activated + ?Sized, C: PacketCodec> Iterator for PacketIter<S, C> {
     type Item = Result<C::Item, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.capture.next() {
+        match self.capture.next_packet() {
             Ok(packet) => Some(Ok(self.codec.decode(packet))),
             Err(Error::NoMorePackets) => None,
             Err(e) => Some(Err(e)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,15 @@ mod raw;
 #[cfg(windows)]
 pub mod sendqueue;
 #[cfg(feature = "capture-stream")]
-pub mod stream;
+mod stream;
+#[cfg(feature = "capture-stream")]
+pub use stream::PacketStream;
+
+mod iterator;
+pub use iterator::PacketIter;
+
+mod codec;
+pub use codec::PacketCodec;
 
 /// An error received from pcap
 #[derive(Debug, PartialEq, Eq)]
@@ -1123,7 +1131,11 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// Blocks until a packet is returned from the capture handle or an error occurs.
     ///
     /// pcap captures packets and places them into a buffer which this function reads
-    /// from. This buffer has a finite length, so if the buffer fills completely new
+    /// from.
+    ///
+    /// # Warning
+    ///
+    /// This buffer has a finite length, so if the buffer fills completely new
     /// packets will be discarded temporarily. This means that in realtime situations,
     /// you probably want to minimize the time between calls of this next() method.
     #[allow(clippy::should_implement_trait)]
@@ -1159,6 +1171,11 @@ impl<T: Activated + ?Sized> Capture<T> {
         }
     }
 
+    /// Return an iterator that call [`Self::next()`] forever. Require a [`PacketCodec`]
+    pub fn iter<C: PacketCodec>(self, codec: C) -> PacketIter<T, C> {
+        PacketIter::new(self, codec)
+    }
+
     /// Returns this capture as a [`futures::Stream`] of packets.
     ///
     /// # Errors
@@ -1166,14 +1183,11 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// If this capture is set to be blocking, or if the network device
     /// does not support `select()`, an error will be returned.
     #[cfg(feature = "capture-stream")]
-    pub fn stream<C: stream::PacketCodec>(
-        self,
-        codec: C,
-    ) -> Result<stream::PacketStream<T, C>, Error> {
+    pub fn stream<C: PacketCodec>(self, codec: C) -> Result<PacketStream<T, C>, Error> {
         if !self.nonblock {
             return Err(NonNonBlock);
         }
-        stream::PacketStream::new(SelectableCapture::new(self)?, codec)
+        PacketStream::new(SelectableCapture::new(self)?, codec)
     }
 
     /// Sets the filter on the capture using the given BPF program string. Internally this is

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,8 +4,8 @@
 use super::Activated;
 use super::Capture;
 use super::Error;
-use super::Packet;
 use super::SelectableCapture;
+use crate::PacketCodec;
 use futures::ready;
 use std::io;
 use std::marker::Unpin;
@@ -13,11 +13,7 @@ use std::pin::Pin;
 use std::task::{self, Poll};
 use tokio::io::unix::AsyncFd;
 
-pub trait PacketCodec {
-    type Type;
-    fn decode(&mut self, packet: Packet) -> Result<Self::Type, Error>;
-}
-
+/// Implement Stream for async use of pcap
 pub struct PacketStream<T: Activated + ?Sized, C> {
     inner: AsyncFd<SelectableCapture<T>>,
     codec: C,
@@ -43,10 +39,12 @@ impl<T: Activated + ?Sized, C> PacketStream<T, C> {
 impl<T: Activated + ?Sized, C> Unpin for PacketStream<T, C> {}
 
 impl<T: Activated + ?Sized, C: PacketCodec> futures::Stream for PacketStream<T, C> {
-    type Item = Result<C::Type, Error>;
+    type Item = Result<C::Item, Error>;
+
     fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
         let stream = Pin::into_inner(self);
         let codec = &mut stream.codec;
+
         loop {
             let mut guard = ready!(stream.inner.poll_read_ready_mut(cx))?;
             match guard.try_io(|inner| match inner.get_mut().inner.next() {
@@ -55,8 +53,7 @@ impl<T: Activated + ?Sized, C: PacketCodec> futures::Stream for PacketStream<T, 
                 Err(e) => Ok(Err(e)),
             }) {
                 Ok(result) => {
-                    let frame_result = result.unwrap()?;
-                    return Poll::Ready(Some(frame_result));
+                    return Poll::Ready(Some(result?));
                 }
                 Err(_would_block) => continue,
             }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -47,7 +47,7 @@ impl<T: Activated + ?Sized, C: PacketCodec> futures::Stream for PacketStream<T, 
 
         loop {
             let mut guard = ready!(stream.inner.poll_read_ready_mut(cx))?;
-            match guard.try_io(|inner| match inner.get_mut().inner.next() {
+            match guard.try_io(|inner| match inner.get_mut().inner.next_packet() {
                 Ok(p) => Ok(Ok(codec.decode(p))),
                 Err(e @ Error::TimeoutExpired) => Err(io::Error::new(io::ErrorKind::WouldBlock, e)),
                 Err(e) => Ok(Err(e)),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -31,7 +31,7 @@ impl<T: Activated + ?Sized, C> PacketStream<T, C> {
     ///
     /// The caller must ensure the capture will not be set to be
     /// blocking.
-    pub fn inner_mut(&mut self) -> &mut Capture<T> {
+    pub fn capture_mut(&mut self) -> &mut Capture<T> {
         &mut self.inner.get_mut().inner
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -25,13 +25,13 @@ type suseconds_t = libc::c_long;
 #[test]
 fn read_packet_with_full_data() {
     let mut capture = capture_from_test_file("packet_snaplen_65535.pcap");
-    assert_eq!(capture.next().unwrap().len(), 98);
+    assert_eq!(capture.next_packet().unwrap().len(), 98);
 }
 
 #[test]
 fn read_packet_with_truncated_data() {
     let mut capture = capture_from_test_file("packet_snaplen_20.pcap");
-    assert_eq!(capture.next().unwrap().len(), 20);
+    assert_eq!(capture.next_packet().unwrap().len(), 20);
 }
 
 fn capture_from_test_file(file_name: &str) -> Capture<Offline> {
@@ -109,9 +109,9 @@ impl Packets {
 
     pub fn verify<T: Activated + ?Sized>(&self, cap: &mut Capture<T>) {
         for (header, data) in self.headers.iter().zip(self.data.iter()) {
-            assert_eq!(cap.next().unwrap(), Packet::new(header, data));
+            assert_eq!(cap.next_packet().unwrap(), Packet::new(header, data));
         }
-        assert!(cap.next().is_err());
+        assert!(cap.next_packet().is_err());
     }
 }
 
@@ -315,7 +315,7 @@ fn test_error() {
 #[test]
 fn test_compile() {
     let mut capture = capture_from_test_file("packet_snaplen_65535.pcap");
-    let packet = capture.next().unwrap();
+    let packet = capture.next_packet().unwrap();
 
     let bpf_capture = Capture::dead(Linktype::ETHERNET).unwrap();
 


### PR DESCRIPTION
There is a lot of change here I will explain my reason:

- while wanting to implement a build-in iterator in pcap, I hit GaTs (as always :p) I choice to follow the `stream` implementation
- The stream implement use a codec to "map" Packet avoid lifetime issue, I changed this trait cause there is no reason a user of pcap to use our pcap Error. If the user want to return an Error it need to return a `Result` as `Item`
- I moved public item cause stream was our only public module, (personally unless a crates is VERY BIG (like tokio, std...) all should be in root if possible)