### PR TITLE
Implement pcap_major/minor_version()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -808,14 +808,12 @@ impl Capture<Offline> {
         })
     }
 
-    /// Get the major version number of the pcap dump file format.
-    pub fn major_version(&self) -> i32 {
-        return unsafe { raw::pcap_major_version(self.handle.as_ptr()) };
-    }
-
-    /// Get the minor version number of the pcap dump file format.
-    pub fn minor_version(&self) -> i32 {
-        return unsafe { raw::pcap_minor_version(self.handle.as_ptr()) };
+    /// Get the (major, minor) version number of the pcap dump file format.
+    pub fn version(&self) -> (i32, i32) {
+        (
+            unsafe { raw::pcap_major_version(self.handle.as_ptr()) as i32 },
+            unsafe { raw::pcap_minor_version(self.handle.as_ptr()) as i32 },
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,12 +810,12 @@ impl Capture<Offline> {
 
     /// Get the major version number of the pcap dump file format.
     pub fn major_version(&self) -> i32 {
-        return unsafe { raw::pcap_major_version(self.handle.as_ptr()) };
+        unsafe { raw::pcap_major_version(self.handle.as_ptr()) }
     }
 
     /// Get the minor version number of the pcap dump file format.
     pub fn minor_version(&self) -> i32 {
-        return unsafe { raw::pcap_minor_version(self.handle.as_ptr()) };
+        unsafe { raw::pcap_minor_version(self.handle.as_ptr()) }
     }
 
     /// Get the (major, minor) version number of the pcap dump file format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -807,6 +807,16 @@ impl Capture<Offline> {
             })
         })
     }
+
+    /// Get the major version number of the pcap dump file format.
+    pub fn major_version(&self) -> i32 {
+        return unsafe { raw::pcap_major_version(self.handle.as_ptr()) };
+    }
+
+    /// Get the minor version number of the pcap dump file format.
+    pub fn minor_version(&self) -> i32 {
+        return unsafe { raw::pcap_minor_version(self.handle.as_ptr()) };
+    }
 }
 
 #[repr(i32)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -808,12 +808,19 @@ impl Capture<Offline> {
         })
     }
 
+    /// Get the major version number of the pcap dump file format.
+    pub fn major_version(&self) -> i32 {
+        return unsafe { raw::pcap_major_version(self.handle.as_ptr()) };
+    }
+
+    /// Get the minor version number of the pcap dump file format.
+    pub fn minor_version(&self) -> i32 {
+        return unsafe { raw::pcap_minor_version(self.handle.as_ptr()) };
+    }
+
     /// Get the (major, minor) version number of the pcap dump file format.
     pub fn version(&self) -> (i32, i32) {
-        (
-            unsafe { raw::pcap_major_version(self.handle.as_ptr()) as i32 },
-            unsafe { raw::pcap_minor_version(self.handle.as_ptr()) as i32 },
-        )
+        (self.major_version(), self.minor_version())
     }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -143,8 +143,8 @@ extern "C" {
     pub fn pcap_datalink_val_to_description(arg1: c_int) -> *const c_char;
     // pub fn pcap_snapshot(arg1: *mut pcap_t) -> c_int;
     // pub fn pcap_is_swapped(arg1: *mut pcap_t) -> c_int;
-    // pub fn pcap_major_version(arg1: *mut pcap_t) -> c_int;
-    // pub fn pcap_minor_version(arg1: *mut pcap_t) -> c_int;
+    pub fn pcap_major_version(arg1: *mut pcap_t) -> c_int;
+    pub fn pcap_minor_version(arg1: *mut pcap_t) -> c_int;
     // pub fn pcap_file(arg1: *mut pcap_t) -> *mut FILE;
     pub fn pcap_fileno(arg1: *mut pcap_t) -> c_int;
     pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -345,4 +345,6 @@ fn test_pcap_version() {
     let capture = capture_from_test_file("packet_snaplen_65535.pcap");
 
     assert_eq!(capture.version(), (2, 4));
+    assert_eq!(capture.major_version(), 2);
+    assert_eq!(capture.minor_version(), 4);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -344,6 +344,5 @@ fn test_compile_optimized() {
 fn test_pcap_version() {
     let capture = capture_from_test_file("packet_snaplen_65535.pcap");
 
-    assert_eq!(capture.major_version(), 2);
-    assert_eq!(capture.minor_version(), 4);
+    assert_eq!(capture.version(), (2, 4));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -339,3 +339,11 @@ fn test_compile_optimized() {
 
     assert!(instr_opt.len() < instr_unopt.len());
 }
+
+#[test]
+fn test_pcap_version() {
+    let capture = capture_from_test_file("packet_snaplen_65535.pcap");
+
+    assert_eq!(capture.major_version(), 2);
+    assert_eq!(capture.minor_version(), 4);
+}


### PR DESCRIPTION
Getting the pcap_major_version()/pcap_minor_version() of a dump file can be handy.
