### PR TITLE
Make struct repr transparent so transmute is safe.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1369,7 +1369,9 @@ fn test_struct_size() {
     assert_eq!(size_of::<PacketHeader>(), size_of::<raw::pcap_pkthdr>());
 }
 
+#[repr(transparent)]
 pub struct BpfInstruction(raw::bpf_insn);
+#[repr(transparent)]
 pub struct BpfProgram(raw::bpf_program);
 
 impl BpfProgram {


### PR DESCRIPTION
A lot of the code assumes that `BpfInstruction` and `BpfProgram` have the same size and layout as their raw counterparts, but they have to have a `repr(transparent)` for that to be safe.

The [nomicon says](https://doc.rust-lang.org/stable/nomicon/transmutes.html):

> When transmuting between different compound types, you have to make sure they are laid out the same way! If layouts differ, the wrong fields are going to get filled with the wrong data, which will make you unhappy and can also be UB (see above).
>
> So how do you know if the layouts are the same? For repr(C) types and repr(transparent) types, layout is precisely defined. ...