### PR TITLE
Add Capture::dead_with_options constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add support for sendqueues on Windows.
 - Add `PacketStream::capture_mut` to still be able to inject packets when using `PacketStream`
 - `Capture::iter()` that return an iterator that use a codec like `Capture::stream()`
+ - Add `Packet<Dead>::dead_with_precision` to enable creating a pcap with nanosecond precision.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1257,6 +1257,20 @@ impl Capture<Dead> {
         ))
     }
 
+    /// Creates a "fake" capture handle for the given link type and timestamp precision.
+    #[cfg(libpcap_1_5_0)]
+    pub fn dead_with_precision(
+        linktype: Linktype,
+        precision: Precision,
+    ) -> Result<Capture<Dead>, Error> {
+        let handle = unsafe {
+            raw::pcap_open_dead_with_tstamp_precision(linktype.0, 65535, precision as u32)
+        };
+        Ok(Capture::from(
+            NonNull::<raw::pcap_t>::new(handle).ok_or(InsufficientMemory)?,
+        ))
+    }
+
     /// Compiles the string into a filter program using `pcap_compile`.
     pub fn compile(&self, program: &str, optimize: bool) -> Result<BpfProgram, Error> {
         let program = CString::new(program).unwrap();


### PR DESCRIPTION
I realized that using a builder isn't actually a backwards-breaking change if I keep the existing method as a shortcut, so here it is.

Fixes #243