### PR TITLE
Complete deviceinterface information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `PacketStream::capture_mut` to still be able to inject packets when using `PacketStream`
 - `Capture::iter()` that return an iterator that use a codec like `Capture::stream()`
  - Add `Packet<Dead>::dead_with_precision` to enable creating a pcap with nanosecond precision.
+ - Add `flags` field to `Device`.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "~1.2"
 libc = "0.2"
 tokio = { version = "1.0", features = ["net", "rt", "macros", "rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 
 [dependencies]
+bitflags = "1.3"
 libc = "0.2"
 tokio = { version = "1.0", features = ["net", "rt", "macros", "rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -1,7 +1,11 @@
 fn main() {
     // list all of the devices pcap tells us are available
     for device in pcap::Device::list().expect("device lookup failed") {
-        println!("Found device! {:?}", device);
+        println!(
+            "Found device! {:?}; ConnectionStatus: {:?}",
+            device,
+            device.flags.connection_status()
+        );
 
         // now you can create a Capture with this Device if you want.
         // see example/easylisten.rs for how

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -1,11 +1,7 @@
 fn main() {
     // list all of the devices pcap tells us are available
     for device in pcap::Device::list().expect("device lookup failed") {
-        println!(
-            "Found device! {:?}; ConnectionStatus: {:?}",
-            device,
-            device.flags.connection_status()
-        );
+        println!("Found device! {:?}", device);
 
         // now you can create a Capture with this Device if you want.
         // see example/easylisten.rs for how

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ impl DeviceFlags {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Indication of whether the adapter is connected or not; for wireless interfaces, "connected"
 /// means "associated with a network".
 pub enum ConnectionStatus {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -6,6 +6,16 @@ use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, sockaddr, timeval, FILE};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
 
+pub const PCAP_IF_LOOPBACK: u32 = 0x00000001;
+pub const PCAP_IF_UP: u32 = 0x00000002;
+pub const PCAP_IF_RUNNING: u32 = 0x00000004;
+pub const PCAP_IF_WIRELESS: u32 = 0x00000008;
+pub const PCAP_IF_CONNECTION_STATUS: u32 = 0x00000030;
+pub const PCAP_IF_CONNECTION_STATUS_UNKNOWN: u32 = 0x00000000;
+pub const PCAP_IF_CONNECTION_STATUS_CONNECTED: u32 = 0x00000010;
+pub const PCAP_IF_CONNECTION_STATUS_DISCONNECTED: u32 = 0x00000020;
+pub const PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE: u32 = 0x00000030;
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct bpf_program {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -364,9 +364,8 @@ fn test_device_flags() {
     pub const PCAP_IF_UP: u32 = 0x00000002;
     pub const PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE: u32 = 0x00000030;
 
-    let flags = DeviceFlags::from_bits_truncate(
-        PCAP_IF_LOOPBACK | PCAP_IF_UP | PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
-    );
+    let flags =
+        DeviceFlags::from(PCAP_IF_LOOPBACK | PCAP_IF_UP | PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE);
 
     assert!(flags.is_loopback());
     assert!(flags.is_up());
@@ -388,21 +387,21 @@ fn test_connection_status() {
     pub const PCAP_IF_CONNECTION_STATUS_DISCONNECTED: u32 = 0x00000020;
     pub const PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE: u32 = 0x00000030;
 
-    let flags = DeviceFlags::from_bits_truncate(PCAP_IF_CONNECTION_STATUS_UNKNOWN);
-    assert_eq!(ConnectionStatus::from(&flags), ConnectionStatus::Unknown);
+    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_UNKNOWN);
+    assert_eq!(ConnectionStatus::from(flags), ConnectionStatus::Unknown);
 
-    let flags = DeviceFlags::from_bits_truncate(PCAP_IF_CONNECTION_STATUS_CONNECTED);
-    assert_eq!(ConnectionStatus::from(&flags), ConnectionStatus::Connected);
+    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_CONNECTED);
+    assert_eq!(ConnectionStatus::from(flags), ConnectionStatus::Connected);
 
-    let flags = DeviceFlags::from_bits_truncate(PCAP_IF_CONNECTION_STATUS_DISCONNECTED);
+    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_DISCONNECTED);
     assert_eq!(
-        ConnectionStatus::from(&flags),
+        ConnectionStatus::from(flags),
         ConnectionStatus::Disconnected
     );
 
-    let flags = DeviceFlags::from_bits_truncate(PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE);
+    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE);
     assert_eq!(
-        ConnectionStatus::from(&flags),
+        ConnectionStatus::from(flags),
         ConnectionStatus::NotApplicable
     );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use tempdir::TempDir;
 
 use pcap::{
-    Activated, Active, Capture, ConnectionStatus, DeviceFlags, Linktype, Offline, Packet,
+    Activated, Active, Capture, ConnectionStatus, DeviceFlags, IfFlags, Linktype, Offline, Packet,
     PacketHeader,
 };
 #[cfg(not(windows))]
@@ -369,15 +369,15 @@ fn test_device_flags() {
 
     assert!(flags.is_loopback());
     assert!(flags.is_up());
-    assert!(flags.contains(DeviceFlags::LOOPBACK | DeviceFlags::UP));
+    assert!(flags.contains(IfFlags::LOOPBACK | IfFlags::UP));
 
     assert!(!flags.is_running());
     assert!(!flags.is_wireless());
 
-    assert_ne!(flags.connection_status(), ConnectionStatus::Unknown);
-    assert_ne!(flags.connection_status(), ConnectionStatus::Connected);
-    assert_ne!(flags.connection_status(), ConnectionStatus::Disconnected);
-    assert_eq!(flags.connection_status(), ConnectionStatus::NotApplicable);
+    assert_ne!(flags.connection_status, ConnectionStatus::Unknown);
+    assert_ne!(flags.connection_status, ConnectionStatus::Connected);
+    assert_ne!(flags.connection_status, ConnectionStatus::Disconnected);
+    assert_eq!(flags.connection_status, ConnectionStatus::NotApplicable);
 }
 
 #[test]
@@ -387,19 +387,19 @@ fn test_connection_status() {
     pub const PCAP_IF_CONNECTION_STATUS_DISCONNECTED: u32 = 0x00000020;
     pub const PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE: u32 = 0x00000030;
 
-    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_UNKNOWN);
+    let flags = PCAP_IF_CONNECTION_STATUS_UNKNOWN;
     assert_eq!(ConnectionStatus::from(flags), ConnectionStatus::Unknown);
 
-    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_CONNECTED);
+    let flags = PCAP_IF_CONNECTION_STATUS_CONNECTED;
     assert_eq!(ConnectionStatus::from(flags), ConnectionStatus::Connected);
 
-    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_DISCONNECTED);
+    let flags = PCAP_IF_CONNECTION_STATUS_DISCONNECTED;
     assert_eq!(
         ConnectionStatus::from(flags),
         ConnectionStatus::Disconnected
     );
 
-    let flags = DeviceFlags::from(PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE);
+    let flags = PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE;
     assert_eq!(
         ConnectionStatus::from(flags),
         ConnectionStatus::NotApplicable


### PR DESCRIPTION
Closes #13 

It turns out that since the original issue was create 7 years ago almost everything has been added to the `Device` struct. The only thing remaining were the `flags` documented at: https://www.tcpdump.org/manpages/pcap_findalldevs.3pcap.html.

This field was slightly problematic as it consisted of two separate items really:
- interface flags, which were actual single-bit flags
- connection status, which was a 2-bit bitmask behind which were 4 enum-like values identifying the connection status

In the end I opted to create a wrapper struct that separates these two. My previous iteration without this wrapper is in commit 606bdc3.