### PR TITLE
Schedule CI for a different time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 6 * * *"
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
The idea being that by picking a time that is less likely to be busy the CI might not fail so regularly.