### PR TITLE
Add Handle that own pointer and call C fn to free a pointer

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,0 +1,36 @@
+#![allow(dead_code)]
+
+use std::ptr::NonNull;
+
+/// MUST NOT IMPLEMENT COPY or CLONE
+/// This struct OWN the pointer
+/// and have a F implementation that will call F to free the pointer.
+#[derive(Debug)]
+pub struct Handle<T> {
+    handle: NonNull<T>,
+    drop: unsafe extern "C" fn(*mut T),
+}
+
+impl<T> Handle<T> {
+    pub fn new(handle: NonNull<T>, drop: unsafe extern "C" fn(*mut T)) -> Self {
+        Self { handle, drop }
+    }
+
+    pub fn as_ptr(&self) -> *mut T {
+        self.handle.as_ptr()
+    }
+
+    pub unsafe fn as_ref(&self) -> &T {
+        self.handle.as_ref()
+    }
+
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        self.handle.as_mut()
+    }
+}
+
+impl<T> Drop for Handle<T> {
+    fn drop(&mut self) {
+        unsafe { (self.drop)(self.as_ptr()) }
+    }
+}


### PR DESCRIPTION
That an idea to avoid fall in trap of Drop impl like in https://github.com/rust-pcap/pcap/pull/244.

The purpose is to limit at maximum the risk of double free, with this `Handle` that own pointer it's very unlucky that a double free happen.

There is still one Drop impl of `BpfProgram` but this is a little more difficult since the free function ask for a struct not a pointer, this struct use a lot of unsafe, see https://github.com/rust-pcap/pcap/issues/261, if we are sure we can malloc to make the clone so we can use free yourself, meaning we could use `Handle::new(ptr, free);`.

With this PR https://github.com/rust-pcap/pcap/pull/244 should not introduce UB.