### PR TITLE
Use a more reliable command to DL winpcap on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           cinst -y winpcap --version 4.1.3.20161116
-          (New-Object System.Net.WebClient).DownloadFile("https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip", "C:/WpdPack.zip")
+          Invoke-WebRequest -Uri "https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip" -OutFile "C:/WpdPack.zip"
           Expand-Archive -LiteralPath C:/WpdPack.zip -DestinationPath C:/
           echo "LIB=C:/WpdPack/Lib/x64" >> $env:GITHUB_ENV
       - name: Select rust toolchain


### PR DESCRIPTION
It's look `(New-Object System.Net.WebClient).DownloadFile` is a sort of async way to download file. Invoke-WebRequest is more "slow" according to what I found but that work perfectly for our need, it's basically curl. This should fix our problem.