### PR TITLE
Fix version for bitflags - bump MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,12 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: ["1.41.0", "1.46.0", stable, beta]
+        toolchain: ["1.46.0", stable, beta]
         profile: ['', --release]
         features: ['', '--all-features']
         exclude:
           # capture-stream is not supported on Windows or compiler versions too old for Tokio.
           - os: windows-latest
-            features: '--all-features'
-          - os: windows-latest
-            toolchain: "1.41.0"
-          # 1.46.0 is only a special requirement on Windows
-          - os: ubuntu-latest
-            toolchain: "1.46.0"
-          - os: macos-latest
-            toolchain: "1.46.0"
-          - toolchain: "1.41.0"
             features: '--all-features'
         include:
           # nightly check is performed on ubuntu only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           # capture-stream is not supported on Windows or compiler versions too old for Tokio.
           - os: windows-latest
             features: '--all-features'
+          - toolchain: "1.46.0"
+            features: '--all-features'
         include:
           # nightly check is performed on ubuntu only.
           - os: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- MSRV is now `1.46.0`.
+
 ## [0.10.0] - 2022-08-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 build = "build.rs"
 
 [dependencies]
-bitflags = "~1.2"
+bitflags = "1.2"
 libc = "0.2"
 errno = "0.2"
 tokio = { version = "1.0", features = ["net", "rt", "macros", "rt-multi-thread"], optional = true }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pcap = { version = "0.10", features = ["capture-stream"] }
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate uses Rust 2018 and requires a compiler version >= 1.41 on Linux and Mac OSX and >= 1.46 on Windows.
+This crate uses Rust 2018 and requires a compiler version >= 1.46.
 
 The feature `capture-stream` depends on `tokio = "1.0"`. Therefore, when `capture-stream` is enabled, this crate requires a compiler version new enough to compile the `tokio` crate.
 


### PR DESCRIPTION
Using `bitflags = "~1.2"` will only allow bitflags versions matching `1.2.x`
Using `bitflags = "1.3.2"` will only allow versions above `1.3.2`.
And as mentioned [here](https://users.rust-lang.org/t/avoid-multiple-usage-of-the-same-crate/61865/3) cargo does not allow multiple semver compatible versions of the same crate, attempting to do so will fail to build.

This all means that if another dependency adds `bitflags = "1.3.2"` (a very common way to specify dependencies) then `cargo update`/`cargo run` will fail:
![image](https://user-images.githubusercontent.com/5120858/185049143-ee107a71-39b9-4c04-a7c2-e3704a9fe362.png)

The easiest way to resolve this is to just bump the MSRV to support bitflags 1.3.

An alternative to the approach in this PR would be finding a way to remove the bitflags dependency entirely, feel free to close this PR and do that if you want.