### PR TITLE
Rename sendqueue Sync enum to SendSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `sendqueue::Sync` to `sendqueue::SendSync` to avoid collision with
+  `Sync` in std's prelude.
+
 ## [0.10.1] - 2022-08-17
 
 ### Changed

--- a/examples/sendqueue.rs
+++ b/examples/sendqueue.rs
@@ -50,7 +50,8 @@ fn main() {
         sq.queue(None, &pktbuf[..14 + 256]).unwrap();
     }
 
-    sq.transmit(&mut cap, pcap::sendqueue::Sync::Off).unwrap();
+    sq.transmit(&mut cap, pcap::sendqueue::SendSync::Off)
+        .unwrap();
 }
 
 #[cfg(not(windows))]

--- a/src/sendqueue.rs
+++ b/src/sendqueue.rs
@@ -1,3 +1,10 @@
+//! WinPcap/npcap sendqueue support module.
+//!
+//! Sending individual packets through WinPcap/npcap can be stunningly slow, since a user-to-kernel
+//! transition is required for each packet transfer.  To alleviate this there's support for
+//! queueing up a batch of packets in userland, requiring only a single transition to kernel to
+//! transmit them all.
+
 use std::convert::TryInto;
 use std::ptr::NonNull;
 
@@ -15,6 +22,10 @@ pub enum Sync {
 }
 
 impl SendQueue {
+    /// Create a new `SendQueue` object with a maximum capacity of `memsize`.
+    ///
+    /// The buffer size `memsize` must be able to contain both packet headers and actual packet
+    /// contents.
     pub fn new(memsize: c_uint) -> Result<Self, Error> {
         let squeue = unsafe { raw::pcap_sendqueue_alloc(memsize) };
         let squeue = NonNull::new(squeue).ok_or(Error::InsufficientMemory)?;
@@ -35,6 +46,9 @@ impl SendQueue {
     }
 
     /// Add a packet to the queue.
+    ///
+    /// The `ts` argument only needs to be a `Some()` value if the transmission mode will be
+    /// synchronous when calling [`SendQueue::transmit()`].
     pub fn queue(&mut self, ts: Option<std::time::Duration>, buf: &[u8]) -> Result<(), Error> {
         let caplen = buf.len().try_into().ok().ok_or(Error::BufferOverflow)?;
         let len = buf.len().try_into().ok().ok_or(Error::BufferOverflow)?;
@@ -42,7 +56,7 @@ impl SendQueue {
         let pkthdr = raw::pcap_pkthdr {
             ts: if let Some(ts) = ts {
                 libc::timeval {
-                    // tv_sec is is currently i32 in libc when building for Windows
+                    // tv_sec is currently i32 in libc when building for Windows
                     tv_sec: ts.as_secs() as i32,
                     tv_usec: ts.subsec_micros() as i32,
                 }
@@ -67,7 +81,11 @@ impl SendQueue {
 
     /// Transmit the contents of the queue.
     ///
-    /// If entire queue was transmitted successfull the queue will be automatically reset.
+    /// If entire queue was transmitted successfully the queue will be automatically reset.
+    ///
+    /// If `sync` is set to `Sync::On` the difference between packet header timestamps
+    /// will be used as a delay between sending each packet.  If `Sync::Off` is used the packets
+    /// will be transmitted with no delay between packets.
     pub fn transmit(&mut self, dev: &mut Capture<Active>, sync: Sync) -> Result<(), Error> {
         let res = unsafe {
             raw::pcap_sendqueue_transmit(dev.handle.as_ptr(), self.0.as_ptr(), sync as i32)

--- a/src/sendqueue.rs
+++ b/src/sendqueue.rs
@@ -8,8 +8,6 @@
 use std::convert::TryInto;
 use std::ptr::NonNull;
 
-use libc::c_uint;
-
 use crate::raw;
 use crate::Error;
 use crate::{Active, Capture};
@@ -26,7 +24,7 @@ impl SendQueue {
     ///
     /// The buffer size `memsize` must be able to contain both packet headers and actual packet
     /// contents.
-    pub fn new(memsize: c_uint) -> Result<Self, Error> {
+    pub fn new(memsize: u32) -> Result<Self, Error> {
         let squeue = unsafe { raw::pcap_sendqueue_alloc(memsize) };
         let squeue = NonNull::new(squeue).ok_or(Error::InsufficientMemory)?;
 

--- a/src/sendqueue.rs
+++ b/src/sendqueue.rs
@@ -14,7 +14,7 @@ use crate::{Active, Capture};
 
 pub struct SendQueue(NonNull<raw::pcap_send_queue>);
 
-pub enum Sync {
+pub enum SendSync {
     Off = 0,
     On = 1,
 }
@@ -81,10 +81,10 @@ impl SendQueue {
     ///
     /// If entire queue was transmitted successfully the queue will be automatically reset.
     ///
-    /// If `sync` is set to `Sync::On` the difference between packet header timestamps
-    /// will be used as a delay between sending each packet.  If `Sync::Off` is used the packets
+    /// If `sync` is set to `SendSync::On` the difference between packet header timestamps
+    /// will be used as a delay between sending each packet.  If `SendSync::Off` is used the packets
     /// will be transmitted with no delay between packets.
-    pub fn transmit(&mut self, dev: &mut Capture<Active>, sync: Sync) -> Result<(), Error> {
+    pub fn transmit(&mut self, dev: &mut Capture<Active>, sync: SendSync) -> Result<(), Error> {
         let res = unsafe {
             raw::pcap_sendqueue_transmit(dev.handle.as_ptr(), self.0.as_ptr(), sync as i32)
         };

--- a/src/sendqueue.rs
+++ b/src/sendqueue.rs
@@ -22,7 +22,7 @@ impl SendQueue {
         Ok(Self(squeue))
     }
 
-    pub fn maxlen(&self) -> c_uint {
+    pub fn maxlen(&self) -> u32 {
         unsafe { self.0.as_ref().maxlen }
     }
 
@@ -30,7 +30,7 @@ impl SendQueue {
         self.len() == 0
     }
 
-    pub fn len(&self) -> c_uint {
+    pub fn len(&self) -> u32 {
         unsafe { self.0.as_ref().len }
     }
 


### PR DESCRIPTION
Fixes https://github.com/rust-pcap/pcap/issues/269