### PR TITLE
Pick up libpcap from pkg-config if available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 - Rename `sendqueue::Sync` to `sendqueue::SendSync` to avoid collision with
   `Sync` in std's prelude.
+- Build script will fall back to `pkg-config` if available and `LIBPCAP_LIBDIR`
+  hasn't been explicitly set.
 
 ## [0.10.1] - 2022-08-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ eui48 = "1.1"
 [build-dependencies]
 libloading = "0.6"
 regex = "1"
+pkg-config = "0.3"
 
 [features]
 # This feature enables access to the function Capture::stream.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,13 @@ To solve this, you can try helping the pcap crate compile the correct feature se
 
 If you are linking dynamically with libpcap, pcap will try to consult libpcap for its version. However, if your library is in an unconventional location and you had to customize `cargo:rustc-link-search=native` in your own build script, pcap's build script is unable to pick up on that and will default to the most recent API version. If you are not using the most recent library version, please communicate the library's location to pcap's build script using the `LIBPCAP_LIBDIR` environment variable.
 
+If `LIBPCAP_LIBDIR` is unset, the build will attempt to find the library via `pkg-config` instead. On most setups, this is the easiest way to get things working and may even eliminate the need for any custom build scripts in your software.
+
 #### Library Version
 
 If setting the library location does not work or you are linking statically, you may need to set the libpcap version manually. You can do this by setting the environment variable `LIBPCAP_VER` to the desired version (e.g. `env LIBPCAP_VER=1.5.0`). By default, if pcap fails to query libpcap/wpcap for its API version, it will assume the newest API so this should only be necessary if you are using an old version of libpcap.
+
+Note that `LIBPCAP_VER` is respected even if you haven't set `LIBPCAP_LIBDIR` and are using `pkg-config`. If it is unset, we'll find whatever available version as long as it's supported by the library.
 
 ## Optional Features
 

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,12 @@ struct Version {
 }
 
 impl Version {
+    const LOWEST_SUPPORTED: Self = Self {
+        major: 1,
+        minor: 0,
+        micro: 0,
+    };
+
     fn new(major: usize, minor: usize, micro: usize) -> Version {
         Version {
             major,
@@ -59,6 +65,17 @@ impl Version {
             minor_str.parse::<usize>()?,
             micro_str.parse::<usize>()?,
         ))
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Version {
+            major,
+            minor,
+            micro,
+        } = self;
+        write!(f, "{}.{}.{}", major, minor, micro)
     }
 }
 
@@ -132,7 +149,7 @@ fn get_libpcap_version(libdirpath: Option<PathBuf>) -> Result<Version, Box<dyn s
 
 fn emit_cfg_flags(version: Version) {
     assert!(
-        version >= Version::new(1, 0, 0),
+        version >= Version::LOWEST_SUPPORTED,
         "required pcap lib version: >=1.0.0"
     );
 
@@ -148,12 +165,21 @@ fn main() {
     println!("cargo:rerun-if-env-changed=LIBPCAP_LIBDIR");
     println!("cargo:rerun-if-env-changed=LIBPCAP_VER");
 
-    let mut libdirpath: Option<PathBuf> = None;
-    if let Ok(libdir) = env::var("LIBPCAP_LIBDIR") {
+    // If user explicitly set LIBPCAP_LIBDIR, honour their wishes. This keeps
+    // existing build scripts running. If it's not set, try pkg-config. If
+    // that's not set, try last ditch effort to build even though library wasn't
+    // explicitly given.
+    let version = if let Ok(libdir) = env::var("LIBPCAP_LIBDIR") {
         println!("cargo:rustc-link-search=native={}", libdir);
-        libdirpath = Some(PathBuf::from(&libdir));
-    }
+        get_libpcap_version(Some(PathBuf::from(&libdir))).unwrap()
+    } else if let Ok(library) = pkg_config::Config::new()
+        .atleast_version(&Version::LOWEST_SUPPORTED.to_string())
+        .probe("libpcap")
+    {
+        Version::parse(&library.version).unwrap()
+    } else {
+        get_libpcap_version(None).unwrap()
+    };
 
-    let version = get_libpcap_version(libdirpath).unwrap();
     emit_cfg_flags(version);
 }


### PR DESCRIPTION
To keep existing behaviour, it will look for `LIBPCAP_LIBDIR` first and only then go the pkg-config way and then go for the hail mary as it used to. This will be less likely to break any existing setup and is similar to `pq-sys` for example.

Fixes #276