### PR TITLE
Replace occurrences of "wpcap" with "npcap" to reduce confusion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pcap
 
-This is a **Rust language** crate for accessing the packet sniffing capabilities of libpcap (or wpcap on Windows). If you need anything, feel free to post an issue or submit a pull request!
+This is a **Rust language** crate for accessing the packet sniffing capabilities of libpcap (or Npcap on Windows). If you need anything, feel free to post an issue or submit a pull request!
 
 [![CI](https://github.com/rust-pcap/pcap/workflows/CI/badge.svg)](https://github.com/rust-pcap/pcap/actions/workflows/ci.yml)
 [![Coverage](https://rust-pcap.github.io/pcap/badges/flat.svg)](https://rust-pcap.github.io/pcap/index.html)
@@ -22,7 +22,7 @@ See [examples](examples) for usage.
 
 # Building
 
-This crate requires the libpcap (or wpcap on Windows) library.
+This crate requires the libpcap (or npcap on Windows) library.
 
 ## Installing dependencies
 


### PR DESCRIPTION
As I understand it, `wpcap` (winpcap) is deprecated and hasn't been developed for some time, I'm also pretty sure it only supports a version of libpcap for **2009**. Though winpcap has lots of api compatibility with npcap and probably works I think it's best that we direct people towards the actively developed npcap as is already done in the build directions for windows.

Ultimately I removed occurrences of wpcap in README.md here to reduce confusion as it tripped me up for a second on first reading.