### PR TITLE
Initial Linux-only virtual interface testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ pkg-config = "0.3"
 # This is disabled by default, because it depends on a tokio
 capture-stream = ["tokio", "futures"]
 tap-tests = []
+# an empty feature to detect if '--all-features' was set
+all-features = []
 
 [lib]
 name = "pcap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ futures = { version = "0.3", optional = true }
 windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
 
 [dev-dependencies]
+etherparse = "0.13.0"
 tempdir = "0.3"
+tun-tap = "0.1.3"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 eui48 = "1.1"
@@ -37,6 +39,7 @@ pkg-config = "0.3"
 # This feature enables access to the function Capture::stream.
 # This is disabled by default, because it depends on a tokio
 capture-stream = ["tokio", "futures"]
+tap-tests = []
 
 [lib]
 name = "pcap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,16 @@ libc = "0.2"
 errno = "0.2"
 tokio = { version = "1.0", features = ["net", "rt", "macros", "rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }
+# these really belong in [dev-dependencies], but can't have optional dev-deps
+# and these libraries would truncate the min support Rust version (MSRV)
+tun-tap = { version = "0.1.3", optional = true }
+etherparse = { version = "0.13.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
 
 [dev-dependencies]
-etherparse = "0.13.0"
 tempdir = "0.3"
-tun-tap = "0.1.3"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 eui48 = "1.1"
@@ -39,7 +41,7 @@ pkg-config = "0.3"
 # This feature enables access to the function Capture::stream.
 # This is disabled by default, because it depends on a tokio
 capture-stream = ["tokio", "futures"]
-tap-tests = []
+tap-tests = ["tun-tap", "etherparse"]
 # an empty feature to detect if '--all-features' was set
 all-features = []
 

--- a/tests/tap_tests.rs
+++ b/tests/tap_tests.rs
@@ -1,0 +1,149 @@
+/***
+* These tests need to be run as root and currently only work on Linux (and maybe MacOs?)
+*
+* To build and run these tests, run:
+*
+
+ cargo test -F tap-tests --no-run --test tap_tests |& \
+           sed -e 's/[()]//g' | awk '/Executable/ {print $3}' | xargs sudo
+
+* which does the build as a non-priv user, extracts the exec binary location of
+* the test from 'cargo test', and runs only that as root.
+*
+* To develop on these tests, you need to manually enable this feature in VSCode ala:
+*
+*  In VS Code, open the Extensions sidebar, click the gear icon next
+*  to the rust-analyzer extension, and choose “Extension Settings.”
+*  You can choose whether to customize settings for all projects (the
+*  “User” tab) or just the current one (the “Workspace” tab). The
+*  setting is labeled “Cargo: Features.”
+*
+* [from https://users.rust-lang.org/t/passing-feature-flags-to-rust-analyzer/45918/3]
+*
+* to debug, run:
+*
+* sudo rust-gdb ./target/debug/deps/tap_test-${BUILD}
+*  break tap_test::tests::<TAB>   # to get a list of useful breakpoints
+*
+* NOTE: tests in rust capture stdio/stderr by default; add "-- --nocapture", e.g.,
+*  'cargo test -- --nocapture'
+*/
+#[cfg(feature = "tap-tests")]
+mod tests {
+
+    use etherparse::{PacketBuilder, PacketHeaders};
+    use pcap::Capture;
+    use tun_tap::Iface;
+
+    /***
+     * Create a Tap interface and make sure that the sendpacket() and next_packet()
+     * work as expected
+     */
+    #[test]
+    fn conntrack_tap_basic() {
+        let (cap, iface) = capture_tap_interface();
+
+        // NOTE: on Linux, if you don't specify a timeout(), it will never return
+        let mut cap = cap.snaplen(32000).timeout(500).open().unwrap();
+
+        // create a test packet
+        let builder1 = PacketBuilder::ethernet2([1, 1, 1, 1, 1, 1], [2, 2, 2, 2, 2, 2])
+            .ipv4([1, 2, 3, 4], [5, 6, 7, 8], 128)
+            .tcp(80, 12345, 1, 32000);
+        let payload1 = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut pkt1 = Vec::with_capacity(builder1.size(payload1.len()));
+        builder1.write(&mut pkt1, &payload1).unwrap();
+
+        // send it in the interface
+        let send_len = iface.send(&pkt1).unwrap();
+        assert_eq!(send_len, pkt1.len());
+
+        // try to pcap capture it
+        let test_pkt1 = cap.next_packet().unwrap();
+        // did we capture the whole packet?
+        assert_eq!(pkt1.len(), test_pkt1.header.caplen as usize);
+        // does it match what we expect?
+        assert_eq!(&pkt1, test_pkt1.data);
+
+        // now, try to pcap send it back out that interface
+        cap.sendpacket(pkt1.clone()).unwrap();
+
+        let mut buf = vec![0; pkt1.len() * 2];
+        let recv_len = iface.recv(&mut buf).unwrap();
+
+        let (test_sendpkt, _) = buf.split_at(recv_len);
+        if recv_len != pkt1.len() {
+            // wtf!?
+            let weird = PacketHeaders::from_ethernet_slice(test_sendpkt).unwrap();
+            panic!("weird packet !! {:#?}", weird);
+        }
+        assert_eq!(pkt1.len(), recv_len);
+        assert_eq!(pkt1, test_sendpkt);
+    }
+
+    /**
+     * Bind a tap interface and attach a pcap capture to it and return both
+     *
+     * Return as a Capture<Inactive> in case the caller wants to set some
+     * different options before opening it (maybe?)
+     */
+
+    fn capture_tap_interface() -> (Capture<pcap::Inactive>, Iface) {
+        use tun_tap::Mode;
+
+        // without_packet_info sets ioctl(fd, IFF_NO_PI ) on the tap fd
+        // as described in https://www.gabriel.urdhr.fr/2021/05/08/tuntap/#packet-information
+        // it's not useful for l2 tap packets, so wouldl like to skip to simplify tests
+        let iface_result = Iface::without_packet_info("testtap%d", Mode::Tap);
+        // I know this could/should be a match(), but I think this is cleaner...
+        if let Err(e) = iface_result {
+            if e.kind() == std::io::ErrorKind::PermissionDenied {
+                println!("Permission denied - needs tp be run as root/sudo!");
+                panic!("Failed to bind the tap interface: PermissionDenied - please run with root/sudo!");
+            }
+            // common error is to not run these tests as root; provide a nicer message
+            panic!("Failed to bind the tap interface: {:#?}", e);
+        }
+        let iface = iface_result.unwrap();
+        if cfg!(target_os = "linux") {
+            // If IPv6 is enabled, it will broadcast all sorts of stuff on this interface
+            // these broadcasts will periodically (heisenbug!) break tests that aren't smart enough
+            // so disable IPv6 on the test interface before we start any captures
+            // It's important to do this BEFORE bringing up the interface else there's still
+            // a race condition (that we were losing more often than not!)
+            safe_run_command(format!(
+                "sysctl -w net.ipv6.conf.{}.disable_ipv6=1",
+                iface.name()
+            ));
+
+            // Under Linux, the interface is created, but defaults to 'down' state, where pcap needs it 'up'
+            // Yes, it's a hack to use the command line instead of an API, but the netdev APIs are messy
+            // TODO: decide if we should move to the https://crates.io/keywords/netlink crate
+            safe_run_command(format!("ip link set dev {} up", iface.name()));
+        }
+        let device = pcap::Device::from(iface.name());
+        (Capture::from_device(device).unwrap(), iface)
+    }
+
+    /**
+     * Run a command on the shell, check the output, and pretty print a panic message and the
+     * stderr if it fails.
+     */
+    fn safe_run_command(cmd: String) {
+        use std::process::Command;
+
+        let mut split_cmd = cmd.split_ascii_whitespace();
+        // the first token is the program and the rest are args()
+        let output = Command::new(split_cmd.next().unwrap())
+            .args(split_cmd.collect::<Vec<&str>>())
+            .output()
+            .unwrap();
+        if !output.status.success() {
+            panic!(
+                "safe_run_command FAILED: '{}' command returned stderr '{:#?}'",
+                cmd,
+                String::from_utf8(output.stderr)
+            );
+        }
+    }
+}

--- a/tests/tap_tests.rs
+++ b/tests/tap_tests.rs
@@ -28,7 +28,7 @@
 * NOTE: tests in rust capture stdio/stderr by default; add "-- --nocapture", e.g.,
 *  'cargo test -- --nocapture'
 */
-#[cfg(feature = "tap-tests")]
+#[cfg(all(feature = "tap-tests", not(feature = "all-features")))]
 mod tests {
 
     use etherparse::{PacketBuilder, PacketHeaders};


### PR DESCRIPTION
This is an end-to-end test of rust pcap and the underlying libpcap and OS. Currently it only works on Linux (and maybe MacOS), must be run with root (at least CAP_NET_ADMIN) permissions.

The test creates a 'TAP' interface
(https://en.wikipedia.org/wiki/TUN/TAP) which is a virtual NIC on one side and a file descriptor on the otherside (to fascilitate testing).

I've hidden it behind a 'tap-tests' cargo feature try to prevent people from accidentally compile it (which requires the 'tun-tap' and 'etherparse' additional dev dependencies) or running it without meeting the above requirements.

Current test just verifies that packets can be sent and received, e.g., do Capture<Active>::next_packet() and Capture<Active>::sendpacket() do the right things.

A fair bit of work is done to avoid race conditions which can be horrible for these types of tests.

	[robs@laptop-o7rs71ij pcap]$ cargo test -F tap-tests --no-run --test
	tap_tests | tail
	    Finished test [unoptimized + debuginfo] target(s) in 0.05s
	  Executable tests/tap_tests.rs
	(target/debug/deps/tap_tests-232532a0859d5255)
	[robs@laptop-o7rs71ij pcap]$ sudo
	./target/debug/deps/tap_tests-232532a0859d5255

	running 1 test
	test tests::conntrack_tap_basic ... ok

	test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered
	out; finished in 0.54s