### PR TITLE
docs: fix broken leading example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! use pcap::Device;
 //!
 //! fn main() {
-//!     let mut cap = Device::lookup().unwrap().open().unwrap();
+//!     let mut cap = Device::lookup().unwrap().unwrap().open();
 //!
 //!     while let Ok(packet) = cap.next_packet() {
 //!         println!("received packet! {:?}", packet);


### PR DESCRIPTION
The first example listed in the documentation is broken and does not compile. This patch fixes the error, allowing it to compile correctly.

Signed-off-by: Amy Parker <apark0006@student.cerritos.edu>