### PR TITLE
Change ToRawFd impl from Active to Activate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1391,7 +1391,7 @@ impl Capture<Dead> {
 }
 
 #[cfg(not(windows))]
-impl AsRawFd for Capture<Active> {
+impl<T: Activated + ?Sized> AsRawFd for Capture<T> {
     /// Returns the file descriptor for a live capture.
     fn as_raw_fd(&self) -> RawFd {
         let fd = unsafe { raw::pcap_fileno(self.handle.as_ptr()) };


### PR DESCRIPTION
The underlying file descriptor in an Capture<Active> can be converted to a raw fd, but so can one from an offline Capture<Offline>, so change the type declaration to reflect that.


I think this is a simple, safe and correct change but feedback welcome.