### PR TITLE
 clippy: variables can be used directly in the format! string

### DIFF
--- a/.github/workflows/ci-steps.yml
+++ b/.github/workflows/ci-steps.yml
@@ -62,9 +62,9 @@ jobs:
         run: cargo test ${{ inputs.profile }} ${{ inputs.features }}
       - name: cargo clippy
         if: inputs.toolchain == 'stable'
-        run: >-
-          cargo clippy ${{ inputs.profile }} ${{ inputs.features }} --
-                       -D warnings
+        run: |-
+          cargo clippy ${{ inputs.profile }} ${{ inputs.features }} -- \
+                       -D warnings \
                        -A clippy::uninlined_format_args
       - name: cargo doc
         run: env DOCS_RS=true cargo doc ${{ inputs.profile }} ${{ inputs.features }} --no-deps

--- a/.github/workflows/ci-steps.yml
+++ b/.github/workflows/ci-steps.yml
@@ -62,10 +62,7 @@ jobs:
         run: cargo test ${{ inputs.profile }} ${{ inputs.features }}
       - name: cargo clippy
         if: inputs.toolchain == 'stable'
-        run: |-
-          cargo clippy ${{ inputs.profile }} ${{ inputs.features }} -- \
-                       -D warnings \
-                       -A clippy::uninlined_format_args
+        run: cargo clippy ${{ inputs.profile }} ${{ inputs.features }} -- -D warnings -A clippy::uninlined_format_args
       - name: cargo doc
         run: env DOCS_RS=true cargo doc ${{ inputs.profile }} ${{ inputs.features }} --no-deps
       - name: cargo fmt

--- a/.github/workflows/ci-steps.yml
+++ b/.github/workflows/ci-steps.yml
@@ -62,7 +62,10 @@ jobs:
         run: cargo test ${{ inputs.profile }} ${{ inputs.features }}
       - name: cargo clippy
         if: inputs.toolchain == 'stable'
-        run: cargo clippy ${{ inputs.profile }} ${{ inputs.features }} -- -D warnings
+        run: >-
+          cargo clippy ${{ inputs.profile }} ${{ inputs.features }} --
+                       -D warnings
+                       -A clippy::uninlined_format_args
       - name: cargo doc
         run: env DOCS_RS=true cargo doc ${{ inputs.profile }} ${{ inputs.features }} --no-deps
       - name: cargo fmt


### PR DESCRIPTION
Allowing the lint instead of fixing as the oldest rust compiler supported by pcap does not support the new feature.