### PR TITLE
Add `lending-iter` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `lending-iter` UNSTABLE feature that introduce lending iterator using GATs
+
 ## [1.0.0] - 2022-11-19
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 errno = "0.2"
 tokio = { version = "1.0", features = ["net", "rt", "macros", "rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }
+gat-std = { version = "0.1.1", optional = true }
 # these really belong in [dev-dependencies], but can't have optional dev-deps
 # and these libraries would truncate the min support Rust version (MSRV)
 tun-tap = { version = "0.1.3", optional = true }
@@ -42,6 +43,7 @@ pkg-config = "0.3"
 # This is disabled by default, because it depends on a tokio
 capture-stream = ["tokio", "futures"]
 tap-tests = ["tun-tap", "etherparse"]
+lending-iter = ["gat-std"]
 # an empty feature to detect if '--all-features' was set
 all-features = []
 
@@ -63,6 +65,11 @@ path = "examples/getstatistics.rs"
 [[example]]
 name = "iterprint"
 path = "examples/iterprint.rs"
+
+[[example]]
+name = "lendingiterprint"
+path = "examples/lendingiterprint.rs"
+required-features = ["lending-iter"]
 
 [[example]]
 name = "listenlocalhost"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ pcap = { version = "1", features = ["capture-stream"] }
 
 **This feature is supported only on Linux and Mac OS X. It will not work and is not supported on Windows.**
 
+## Unstable Features
+
+Use at your own risk, we do not consider this our public API yet.
+
+### `lending-iter`
+
+Use the `lending-iter` feature to enable the lending packet iterator. See `lendingiterprint` example.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate uses Rust 2018 and requires a compiler version >= 1.46.

--- a/examples/lendingiterprint.rs
+++ b/examples/lendingiterprint.rs
@@ -1,0 +1,23 @@
+//! Example of using lending iterators that print paquet
+use pcap::{Capture, Device};
+use std::error;
+
+use gat_std::gatify;
+
+#[gatify]
+fn main() -> Result<(), Box<dyn error::Error>> {
+    let device = Device::lookup()?.ok_or("no device available")?;
+
+    // get the default Device
+    println!("Using device {}", device.name);
+
+    let cap = Capture::from_device(device)?.immediate_mode(true).open()?;
+
+    for packet in cap {
+        let packet = packet?;
+
+        println!("{:?}", packet);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This show how GATs can be used for our problem that lifetime of paquet is link to capture lifetime. However, this is behind a `lending-iter` feature that I think should be considered not a part of our public api.