### PR TITLE
Revert "replace tempdir with tempfile"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ etherparse = { version = "0.13.0", optional = true }
 windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
 
 [dev-dependencies]
-tempfile = "3"
+tempdir = "0.3"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
 eui48 = "1.1"

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,7 +2,7 @@
 use std::io;
 use std::ops::Add;
 use std::path::Path;
-use tempfile::TempDir;
+use tempdir::TempDir;
 
 use pcap::{
     Activated, Active, Capture, ConnectionStatus, DeviceFlags, IfFlags, Linktype, Offline, Packet,
@@ -135,7 +135,7 @@ fn capture_dead_savefile() {
     packets.push(1460408319, 1234, 1, 1, &[1]);
     packets.push(1460408320, 4321, 1, 1, &[2]);
 
-    let dir = TempDir::new().unwrap();
+    let dir = TempDir::new("pcap").unwrap();
     let tmpfile = dir.path().join("test.pcap");
 
     let cap = Capture::dead(Linktype(1)).unwrap();
@@ -158,7 +158,7 @@ fn capture_dead_savefile_append() {
     packets2.push(1460408322, 5432, 1, 1, &[4]);
     let packets = &packets1 + &packets2;
 
-    let dir = TempDir::new().unwrap();
+    let dir = TempDir::new("pcap").unwrap();
     let tmpfile = dir.path().join("test.pcap");
 
     let cap = Capture::dead(Linktype(1)).unwrap();
@@ -198,7 +198,7 @@ fn test_raw_fd_api() {
         );
     }
 
-    let dir = TempDir::new().unwrap();
+    let dir = TempDir::new("pcap").unwrap();
     let tmpfile = dir.path().join("test.pcap");
 
     // Write all packets to test.pcap savefile


### PR DESCRIPTION
Reverts rust-pcap/pcap#295

Does not work with MSRV.