### PR TITLE
Add example with saving packets to different files

### DIFF
--- a/examples/savemultiplefiles.rs
+++ b/examples/savemultiplefiles.rs
@@ -1,0 +1,32 @@
+use pcap::Capture;
+
+fn main() {
+    // get the default Device
+    let device = pcap::Device::lookup().unwrap().unwrap();
+
+    // Setup Capture
+    let mut cap = pcap::Capture::from_device(device)
+        .unwrap()
+        .immediate_mode(true)
+        .open()
+        .unwrap();
+
+    // remember linktype to create PCAP files later
+    let linktype = cap.get_datalink();
+
+    // Save each 30 packets into a new PCAP file
+    let mut counter = 0;
+    loop {
+        let mut save_file = Capture::dead(linktype)
+            .unwrap()
+            .savefile(format!("dump_{}.pcap", counter))
+            .unwrap();
+
+        for _ in 0..30 {
+            let packet = cap.next_packet().unwrap();
+            save_file.write(&packet);
+        }
+
+        counter += 1;
+    }
+}

--- a/examples/savemultiplefiles.rs
+++ b/examples/savemultiplefiles.rs
@@ -15,17 +15,21 @@ fn main() {
     let linktype = cap.get_datalink();
 
     // Save each 30 packets into a new PCAP file
-    let mut counter = 0;
-    loop {
+    let mut counter: usize = 0;
+
+    // For example purposes we will only save 5 files...
+    for _ in 0..5 {
         let mut save_file = Capture::dead(linktype)
             .unwrap()
             .savefile(format!("dump_{}.pcap", counter))
             .unwrap();
 
+        // ...30 packets each
         for _ in 0..30 {
             let packet = cap.next_packet().unwrap();
             save_file.write(&packet);
         }
+        save_file.flush().unwrap();
 
         counter += 1;
     }

--- a/examples/savemultiplefiles.rs
+++ b/examples/savemultiplefiles.rs
@@ -14,11 +14,8 @@ fn main() {
     // remember linktype to create PCAP files later
     let linktype = cap.get_datalink();
 
-    // Save each 30 packets into a new PCAP file
-    let mut counter: usize = 0;
-
     // For example purposes we will only save 5 files...
-    for _ in 0..5 {
+    for counter in 0..5 {
         let mut save_file = Capture::dead(linktype)
             .unwrap()
             .savefile(format!("dump_{}.pcap", counter))
@@ -30,7 +27,5 @@ fn main() {
             save_file.write(&packet);
         }
         save_file.flush().unwrap();
-
-        counter += 1;
     }
 }


### PR DESCRIPTION
This PR adds an example of using Capture::dead() to save packets from an active Capture to different files.

## Reason
Splitting the PCAP stream (either in-flight or from an existing file) is a common task, and currently, no example covers it. If a user tries to create `SaveFile` from the same active Capture, errors are not helping a lot (current errors are about mutable and immutable borrows, while the right approach - create new Captures with a `dead` parameter).

