### PR TITLE
Add a binding for pcap_loop

### DIFF
--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -1,0 +1,23 @@
+fn main() {
+    // get the default Device
+    let device = pcap::Device::lookup()
+        .expect("device lookup failed")
+        .expect("no device available");
+    println!("Using device {}", device.name);
+
+    // Setup Capture
+    let mut cap = pcap::Capture::from_device(device)
+        .unwrap()
+        .immediate_mode(true)
+        .open()
+        .unwrap();
+
+    let mut count = 0;
+    cap.for_each(|packet| {
+        println!("Got {:?}", packet.header);
+        count += 1;
+        if count > 100 {
+            panic!("ow");
+        }
+    });
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -99,8 +99,9 @@ pub struct pcap_send_queue {
     pub buffer: *mut c_char,
 }
 
+// This is not Option<fn>, pcap functions do not check if the handler is null.
 pub type pcap_handler =
-    Option<extern "C" fn(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar) -> ()>;
+    extern "C" fn(user: *mut c_uchar, h: *const pcap_pkthdr, bytes: *const c_uchar) -> ();
 
 extern "C" {
     // [OBSOLETE] pub fn pcap_lookupdev(arg1: *mut c_char) -> *mut c_char;
@@ -119,8 +120,12 @@ extern "C" {
     pub fn pcap_open_offline(arg1: *const c_char, arg2: *mut c_char) -> *mut pcap_t;
     pub fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t;
     pub fn pcap_close(arg1: *mut pcap_t);
-    // pub fn pcap_loop(arg1: *mut pcap_t, arg2: c_int,
-    //                  arg3: pcap_handler, arg4: *mut c_uchar) -> c_int;
+    pub fn pcap_loop(
+        arg1: *mut pcap_t,
+        arg2: c_int,
+        arg3: pcap_handler,
+        arg4: *mut c_uchar,
+    ) -> c_int;
     // pub fn pcap_dispatch(arg1: *mut pcap_t, arg2: c_int, arg3: pcap_handler,
     //                      arg4: *mut c_uchar)-> c_int;
     // pub fn pcap_next(arg1: *mut pcap_t, arg2: *mut pcap_pkthdr) -> *const c_uchar;
@@ -129,7 +134,7 @@ extern "C" {
         arg2: *mut *mut pcap_pkthdr,
         arg3: *mut *const c_uchar,
     ) -> c_int;
-    // pub fn pcap_breakloop(arg1: *mut pcap_t);
+    pub fn pcap_breakloop(arg1: *mut pcap_t);
     pub fn pcap_stats(arg1: *mut pcap_t, arg2: *mut pcap_stat) -> c_int;
     pub fn pcap_setfilter(arg1: *mut pcap_t, arg2: *mut bpf_program) -> c_int;
     pub fn pcap_setdirection(arg1: *mut pcap_t, arg2: pcap_direction_t) -> c_int;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -32,6 +32,16 @@ fn read_packet_with_full_data() {
 }
 
 #[test]
+fn read_packet_via_pcap_loop() {
+    let mut packets = 0;
+    let mut capture = capture_from_test_file("packet_snaplen_65535.pcap");
+    capture.pcap_loop(|_| {
+        packets += 1;
+    });
+    assert_eq!(packets, 1);
+}
+
+#[test]
 fn read_packet_with_truncated_data() {
     let mut capture = capture_from_test_file("packet_snaplen_20.pcap");
     assert_eq!(capture.next_packet().unwrap().len(), 20);


### PR DESCRIPTION
I recently ran into a situation where a tool I help maintain and `tcpdump` had different behavior with a somewhat exotic libpcap implementation. I eventually tracked this down to the fact that `tcpdump` uses `pcap_loop` and since said tool is going through this crate, it was using `pcap_next_ex`. This difference was actually a bug in the libpcap implementation, I spent a frustrating amount of time convincing people that the bug was in libpcap, because I couldn't closely imitate the libpcap calls of `tcpdump`.

Since that time, I've been wanting a way to call `pcap_loop` from this crate, because that would have made my life a lot easier. So I finally got around to putting one together, here it is.

I don't really care about the public API. Ideas like a better name are very welcome.