### PR TITLE
Update windows-sys dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Crate maintenance: Use `windows-sys` version `0.48.0`.
+- Deprecate `open_raw_fd()`.
+
 ## [1.1.0] - 2023-05-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tun-tap = { version = "0.1.3", optional = true }
 etherparse = { version = "0.13.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1485,6 +1485,10 @@ impl Drop for Savefile {
 /// # Safety
 ///
 /// Unsafe, because the returned FILE assumes it is the sole owner of the file descriptor.
+#[deprecated(
+    since = "1.1.1",
+    note = "Out of scope for pcap. Will be removed next major version."
+)]
 pub unsafe fn open_raw_fd(fd: RawFd, mode: u8) -> Result<*mut libc::FILE, Error> {
     let mode = [mode, 0];
     libc::fdopen(fd, mode.as_ptr() as _)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1486,7 +1486,7 @@ impl Drop for Savefile {
 ///
 /// Unsafe, because the returned FILE assumes it is the sole owner of the file descriptor.
 pub unsafe fn open_raw_fd(fd: RawFd, mode: u8) -> Result<*mut libc::FILE, Error> {
-    let mode = vec![mode, 0];
+    let mode = [mode, 0];
     libc::fdopen(fd, mode.as_ptr() as _)
         .as_mut()
         .map(|f| f as _)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,7 @@ impl Address {
             return None;
         }
 
-        match (*ptr).sa_family as u32 {
+        match (*ptr).sa_family {
             AF_INET => {
                 let ptr: *const SOCKADDR_IN = std::mem::transmute(ptr);
                 let addr: [u8; 4] = ((*ptr).sin_addr.S_un.S_addr).to_ne_bytes();


### PR DESCRIPTION
`windows-sys` has been at `0.48` for some time now, and is pretty widely used.  I think we should upgrade to it.

There was one minor fallout; `sa_family` is a `u16`, but for some odd-ball reason it was `u32` in `0.36.1`.  (This was likely due to a now-fixed bug in the `win32metadata` project, which is used to generate the `windows-sys` crate).

No external interfaces are affected (apart from `HANDLE` being from `windows-sys` `0.48` rather than `0.36.1`).