### PR TITLE
Fix complaints from a 2021 clippy

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -8,5 +8,5 @@ use crate::Packet;
 pub trait PacketCodec {
     type Item;
 
-    fn decode(&mut self, packet: Packet) -> Self::Item;
+    fn decode(&mut self, packet: Packet<'_>) -> Self::Item;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             MalformedError(ref e) => write!(f, "libpcap returned invalid UTF-8: {}", e),
             InvalidString => write!(f, "libpcap returned a null string"),
@@ -686,7 +686,7 @@ pub struct PacketHeader {
 }
 
 impl fmt::Debug for PacketHeader {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "PacketHeader {{ ts: {}.{:06}, caplen: {}, len: {} }}",
@@ -1233,7 +1233,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// This buffer has a finite length, so if the buffer fills completely new
     /// packets will be discarded temporarily. This means that in realtime situations,
     /// you probably want to minimize the time between calls to next_packet() method.
-    pub fn next_packet(&mut self) -> Result<Packet, Error> {
+    pub fn next_packet(&mut self) -> Result<Packet<'_>, Error> {
         unsafe {
             let mut header: *mut raw::pcap_pkthdr = ptr::null_mut();
             let mut packet: *const libc::c_uchar = ptr::null();
@@ -1447,7 +1447,7 @@ unsafe impl Send for Savefile {}
 
 impl Savefile {
     /// Write a packet to a capture file
-    pub fn write(&mut self, packet: &Packet) {
+    pub fn write(&mut self, packet: &Packet<'_>) {
         unsafe {
             raw::pcap_dump(
                 self.handle.as_ptr() as _,


### PR DESCRIPTION
I was searching for discussion about this crate and happened to find someone who was confused by the implicit lifetimes. So I locally bumped the edition and looked at what `cargo clippy` complained about. They all seem like reasonable changes to me, and hopefully the explicit lifetimes help out future newcomers.