### PR TITLE
Fix IPv4 initialization for test_address_ipv4

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -388,7 +388,7 @@ mod tests {
         let mut addr: WinSock::SOCKADDR_IN = InetAddressV4::new();
 
         addr.sin_port = 1075;
-        addr.set_addr(0x4200000A);
+        addr.set_addr(0x0A000042_u32.to_be());
 
         Sockaddr::SockaddrIn(addr)
     }


### PR DESCRIPTION
The address used in the test was incorrectly initialized on big-endian hosts.

Fixes #347.

I tested this as a patch using real `s390x` hardware.