### PR TITLE
Do not run CI on beta or nightly

### DIFF
--- a/.github/workflows/00-linux.yml
+++ b/.github/workflows/00-linux.yml
@@ -15,25 +15,12 @@ jobs:
       os: 'ubuntu-latest'
       toolchain: 'stable'
 
-  linux-build-and-test-beta:
-    uses: './.github/workflows/01-build-and-test-unix.yml'
-    with:
-      os: 'ubuntu-latest'
-      toolchain: 'beta'
-
   linux-build-and-test-msrv:
     uses: './.github/workflows/01-build-and-test-unix.yml'
     with:
       os: 'ubuntu-latest'
       toolchain: '1.63'
       msrv: true
-
-  # Nightly check is performed on ubuntu only.
-  linux-build-and-test-nightly:
-    uses: './.github/workflows/01-build-and-test-unix.yml'
-    with:
-      os: 'ubuntu-latest'
-      toolchain: 'nightly'
 
   linux-coverage-stable:
     uses: './.github/workflows/02-coverage.yml'

--- a/.github/workflows/00-macos.yml
+++ b/.github/workflows/00-macos.yml
@@ -15,12 +15,6 @@ jobs:
       os: 'macos-latest'
       toolchain: 'stable'
 
-  macos-build-and-test-beta:
-    uses: './.github/workflows/01-build-and-test-unix.yml'
-    with:
-      os: 'macos-latest'
-      toolchain: 'beta'
-
   macos-build-and-test-msrv:
     uses: './.github/workflows/01-build-and-test-unix.yml'
     with:

--- a/.github/workflows/00-windows.yml
+++ b/.github/workflows/00-windows.yml
@@ -18,15 +18,6 @@ jobs:
       NPCAP_OEM_PASSWORD: ${{ secrets.NPCAP_OEM_PASSWORD }}
       NPCAP_OEM_USERNAME: ${{ secrets.NPCAP_OEM_USERNAME }}
 
-  windows-build-and-test-beta:
-    uses: './.github/workflows/01-build-and-test-windows.yml'
-    with:
-      os: 'windows-latest'
-      toolchain: 'beta'
-    secrets:
-      NPCAP_OEM_PASSWORD: ${{ secrets.NPCAP_OEM_PASSWORD }}
-      NPCAP_OEM_USERNAME: ${{ secrets.NPCAP_OEM_USERNAME }}
-
   windows-build-and-test-msrv:
     uses: './.github/workflows/01-build-and-test-windows.yml'
     with:


### PR DESCRIPTION
I do not have time to support beta and nightly and resolve their issues. If issues make it to stable, they will still be caught before an actual package release.

Motivated by https://github.com/rust-pcap/pcap/issues/340 which exhibits weird beta DLL failures which have since been fixed in Nightly (though not clear if it will make it 1.78).

Occasionally issues can be addressed as the pipeline supports different toolchains.