### PR TITLE
Add `want_pktap` on `Capture<Inactive>`

### DIFF
--- a/.github/workflows/01-build-and-test-unix.yml
+++ b/.github/workflows/01-build-and-test-unix.yml
@@ -43,6 +43,10 @@ jobs:
         run: cargo build --lib --tests
         env:
           LIBPCAP_VER: '1.5.0'
+      - name: 'LIBPCAP_VER: 1.5.3'
+        run: cargo build --lib --tests
+        env:
+          LIBPCAP_VER: '1.5.3'
       - name: 'LIBPCAP_VER: 1.7.2'
         run: cargo build --lib --tests
         env:

--- a/build.rs
+++ b/build.rs
@@ -29,6 +29,7 @@ impl Version {
         vec![
             Version::new(1, 2, 1),
             Version::new(1, 5, 0),
+            Version::new(1, 5, 3),
             Version::new(1, 7, 2),
             Version::new(1, 9, 0),
             Version::new(1, 9, 1),

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -267,6 +267,17 @@ pub mod ffi_unix {
     }
 }
 
+#[cfg(target_os = "macos")]
+#[cfg_attr(test, automock)]
+pub mod ffi_macos {
+    use super::*;
+
+    #[cfg(libpcap_1_5_3)]
+    extern "C" {
+        pub fn pcap_set_want_pktap(arg1: *mut pcap_t, arg2: c_int) -> c_int;
+    }
+}
+
 #[cfg(windows)]
 #[cfg_attr(test, automock)]
 pub mod ffi_windows {
@@ -306,6 +317,10 @@ pub use ffi::*;
 pub use ffi_unix::*;
 
 #[cfg(not(test))]
+#[cfg(target_os = "macos")]
+pub use ffi_macos::*;
+
+#[cfg(not(test))]
 #[cfg(windows)]
 pub use ffi_windows::*;
 
@@ -315,6 +330,10 @@ pub use mock_ffi::*;
 #[cfg(test)]
 #[cfg(not(windows))]
 pub use mock_ffi_unix::*;
+
+#[cfg(test)]
+#[cfg(target_os = "macos")]
+pub use mock_ffi_macos::*;
 
 #[cfg(test)]
 #[cfg(windows)]


### PR DESCRIPTION
This PR adds a binding for the macOS-specific `pcap_set_want_pktap` and exposes it on the `Capture<Inactive>` state. This function is not that well documented, but it exists in Apple's fork of `libpcap` since version `1.5.3`: https://opensource.apple.com/source/libpcap/libpcap-48/libpcap/pcap-bpf.c.auto.html