### PR TITLE
Implement AsFd for Capture<Active>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an implementation of `AsFd` on `Capture<Active>` on non-Windows.
+
 ## [2.1.0] - 2024-08-27
 
 ### Added


### PR DESCRIPTION
I wanted to use [`nix::poll::poll`](https://docs.rs/nix/latest/nix/poll/fn.poll.html) to wait for the next packet, and a `BorrowedFd` is needed.