### PR TITLE
Bump windows-sys to 0.59.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = { version = "0.3", optional = true }
 gat-std = { version = "0.1.1", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 etherparse = "0.13.0"

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -222,6 +222,8 @@ pub mod testmod {
 
 #[cfg(test)]
 mod tests {
+    use core::ffi::c_void;
+
     use crate::{
         capture::testmod::test_capture,
         raw::testmod::{as_pcap_t, RAWMTX},
@@ -276,10 +278,10 @@ mod tests {
         let ctx = raw::pcap_getevent_context();
         ctx.expect()
             .withf_st(move |arg1| *arg1 == pcap)
-            .return_once(|_| 5);
+            .return_once(|_| 5 as *mut c_void);
 
         let handle = unsafe { capture.get_event() };
-        assert_eq!(handle, 5);
+        assert_eq!(handle, 5 as *mut c_void);
     }
 
     #[test]

--- a/src/device.rs
+++ b/src/device.rs
@@ -266,7 +266,7 @@ impl Address {
             return None;
         }
 
-        match (*ptr).sa_family as u32 {
+        match (*ptr).sa_family as u16 {
             WinSock::AF_INET => {
                 let ptr: *const WinSock::SOCKADDR_IN = std::mem::transmute(ptr);
                 let addr: [u8; 4] = ((*ptr).sin_addr.S_un.S_addr).to_ne_bytes();


### PR DESCRIPTION
Simple windows-sys version bump to the latest published crate version.