### PR TITLE
Use normal stream terminating mechanism

### DIFF
--- a/src/stream/unix.rs
+++ b/src/stream/unix.rs
@@ -58,6 +58,9 @@ impl<T: Activated + ?Sized, C: PacketCodec> futures::Stream for PacketStream<T, 
                     Err(e) => Ok(Err(e)),
                 },
             ) {
+                Ok(Ok(Err(Error::NoMorePackets))) => {
+                    return Poll::Ready(None);
+                }
                 Ok(result) => {
                     return Poll::Ready(Some(result?));
                 }


### PR DESCRIPTION
`Stream`, like `Iterator`, returns an `Option` to indicate end-of-stream with `None`. Implement this.