### PR TITLE
Make docs.rs source view generate links to definitions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.4"
 tempfile = "3.10"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-eui48 = "1.1"
+eui48 = { version = "1.1", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tun-tap = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,4 @@ required-features = ["capture-stream"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.4"
 tempfile = "3.10"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-eui48 = { version = "1.1", default-features = false }
+eui48 = "1.1"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tun-tap = "0.1.3"


### PR DESCRIPTION
When browsing the source on docs.rs it's nice to be able to click on items to reach their definitions.  This is supported, but is opt-in (which this patch does).  (See https://docs.rs/ump/latest/src/ump/lib.rs.html#111 for an example of what this can look like).