### PR TITLE
Disable default features for eui48 to avoid pulling in rustc-serialize.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.4"
 tempfile = "3.10"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-eui48 = "1.1"
+eui48 = { version = "1.1", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tun-tap = "0.1.3"


### PR DESCRIPTION
rustc-serialize has a history of causing builds to output annoying deprecation warnings.  Explicitly make sure that won't happen in the future by disabling all default features from eui48 crate.