### PR TITLE
Use windows-sys 0.59.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = { version = "0.3", optional = true }
 gat-std = { version = "0.1.1", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.36.1", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 etherparse = "0.13.0"

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -276,10 +276,10 @@ mod tests {
         let ctx = raw::pcap_getevent_context();
         ctx.expect()
             .withf_st(move |arg1| *arg1 == pcap)
-            .return_once(|_| 5);
+            .return_once(|_| 5 as *mut std::ffi::c_void);
 
         let handle = unsafe { capture.get_event() };
-        assert_eq!(handle, 5);
+        assert_eq!(handle, 5 as *mut std::ffi::c_void);
     }
 
     #[test]

--- a/src/device.rs
+++ b/src/device.rs
@@ -266,7 +266,7 @@ impl Address {
             return None;
         }
 
-        match (*ptr).sa_family as u32 {
+        match (*ptr).sa_family {
             WinSock::AF_INET => {
                 let ptr: *const WinSock::SOCKADDR_IN = std::mem::transmute(ptr);
                 let addr: [u8; 4] = ((*ptr).sin_addr.S_un.S_addr).to_ne_bytes();
@@ -372,7 +372,7 @@ mod tests {
         fn new() -> Self {
             let mut addr: Self = unsafe { std::mem::zeroed() };
             // The cast is only necessary due to a bug in windows_sys@v0.36.1
-            addr.sin_family = WinSock::AF_INET as u16;
+            addr.sin_family = WinSock::AF_INET;
             addr
         }
 
@@ -418,7 +418,7 @@ mod tests {
         fn new() -> Self {
             let mut addr: Self = unsafe { std::mem::zeroed() };
             // The cast is only necessary due to a bug in windows_sys@v0.36.1
-            addr.sin6_family = WinSock::AF_INET6 as u16;
+            addr.sin6_family = WinSock::AF_INET6;
             unsafe {
                 addr.sin6_addr.u.Byte[0] = 0xFE;
                 addr.sin6_addr.u.Byte[1] = 0x80;


### PR DESCRIPTION
Upgrade to windows-sys 0.59.

Biggest fallout that was fixed:
- Earlier windows-sys crate defined `HANDLE` as a `usize`.  However, technically it's a `void*`, which is what later windows-sys crates use instead.  Because `c_void` is `!Send` this made it impossible to pass the `HANDLE` into a the tokio thread pool.  To work around this, a `Send`:able newtype was introduced for the sole purpose of passing the event `HANDLE` over the thread boundary.  Not pretty, but completely hidden from user.

Other:
- windows-sys used to have some weird inconsistencies where well-known 16-bit constants where made 32-bit, but not all related interfaces were changed to match.  All these seem to have been fixed to proper 16-bit values.
- Some tests have constants that rely on `HANDLE` being `usize`.  These just naively cast to `*mut std::ffi::c_void` now.