### PR TITLE
Sendqueue pkt header size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `packet_header_size()` for applications that need to know the size of internal type
+  `pcap_pkthdr` (for instance to calculate exact send queue sizes).
+
+want to precalculate exact queue sizes.
+
 ## [2.2.0] - 2024-09-01
 
 ### Added
 
 - Added an implementation of `AsFd` on `Capture<Active>` on non-Windows.
-- Added `SendQueue::packet_header_size()` for applications that want to
-  precalculate exact queue sizes.
 
 ## [2.1.0] - 2024-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Added
 
 - Added an implementation of `AsFd` on `Capture<Active>` on non-Windows.
+- Added `SendQueue::packet_header_size()` for applications that want to
+  precalculate exact queue sizes.
 
 ## [2.1.0] - 2024-08-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.4"
 tempfile = "3.10"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-eui48 = "1.1"
+eui48 = { version = "1.1", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tun-tap = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,4 @@ required-features = ["capture-stream"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.4"
 tempfile = "3.10"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-eui48 = { version = "1.1", default-features = false }
+eui48 = "1.1"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tun-tap = "0.1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,14 @@ impl From<std::io::ErrorKind> for Error {
     }
 }
 
+/// Return size of a commonly used packet header.
+///
+/// On Windows this packet header is implicitly added to send queues, so this size must be known
+/// if an application needs to precalculate the exact send queue buffer size.
+pub const fn packet_header_size() -> usize {
+    std::mem::size_of::<raw::pcap_pkthdr>()
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error as StdError;
@@ -278,5 +286,13 @@ mod tests {
                 _ => assert!(error.cause().is_none()),
             }
         }
+    }
+
+    #[test]
+    fn test_packet_size() {
+        assert_eq!(
+            packet_header_size(),
+            std::mem::size_of::<raw::pcap_pkthdr>()
+        );
     }
 }

--- a/src/sendqueue/windows.rs
+++ b/src/sendqueue/windows.rs
@@ -53,6 +53,12 @@ impl SendQueue {
         Ok(Self(squeue))
     }
 
+    /// Return the size of the packet header that is implicitly added to the queue with each new
+    /// packet.
+    pub const fn packet_header_size() -> usize {
+        std::mem::size_of::<raw::pcap_pkthdr>()
+    }
+
     pub fn maxlen(&self) -> u32 {
         unsafe { self.0.as_ref().maxlen }
     }

--- a/src/sendqueue/windows.rs
+++ b/src/sendqueue/windows.rs
@@ -46,6 +46,9 @@ impl SendQueue {
     ///
     /// The buffer size `memsize` must be able to contain both packet headers and actual packet
     /// contents.
+    ///
+    /// Applications that need to precalculate exact buffer sizes can use [`packet_header_size()`](crate::packet_header_size())
+    /// to get the size of the header that is implicitly added along with each packet.
     pub fn new(memsize: u32) -> Result<Self, Error> {
         let squeue = unsafe { raw::pcap_sendqueue_alloc(memsize) };
         let squeue = NonNull::new(squeue).ok_or(Error::InsufficientMemory)?;

--- a/src/sendqueue/windows.rs
+++ b/src/sendqueue/windows.rs
@@ -53,12 +53,6 @@ impl SendQueue {
         Ok(Self(squeue))
     }
 
-    /// Return the size of the packet header that is implicitly added to the queue with each new
-    /// packet.
-    pub const fn packet_header_size() -> usize {
-        std::mem::size_of::<raw::pcap_pkthdr>()
-    }
-
     pub fn maxlen(&self) -> u32 {
         unsafe { self.0.as_ref().maxlen }
     }


### PR DESCRIPTION
There's currently a gap for applications that want to precalculate the exact `SendQueue` size required for a batch of packets -- the application doesn't know[*] the exact size of the packet header that is implicitly added with each packet.  This PR adds a constant function, tied to `SendQueue`, that will allow applications to easily get the size without bothering with any other details.

[*] Well, this isn't technically true -- it happens to be the same size and layout as packet headers found elsewhere in the crate.  However, the benefit of this implementation is that it considers the exact type an implementation detail that the application doesn't need to care about.