### PR TITLE
Docsrs labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.4"
 tempfile = "3.10"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-eui48 = "1.1"
+eui48 = { version = "1.1", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tun-tap = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,4 @@ required-features = ["capture-stream"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,4 +109,4 @@ required-features = ["capture-stream"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--generate-link-to-definition"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.4"
 tempfile = "3.10"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-eui48 = { version = "1.1", default-features = false }
+eui48 = "1.1"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 tun-tap = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ Some dependencies no longer support our chosen MSRV. Since many crates do not co
 
 [Discuss the MSRV](https://github.com/rust-pcap/pcap/discussions/240).
 
+# Documentation labels
+
+Generating documentation with `cfg` labels requires a nightly toolchain.  To
+use this feature set the environment variables:
+
+```
+RUSTFLAGS="--cfg docsrs"
+RUSTDOCFLAGS="--cfg docsrs"
+```
+
+Then generate the documentation using `cargo +nightly doc --all-features`.
+
 # License
 
 Licensed under either of

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -1,6 +1,7 @@
 pub mod activated;
 pub mod inactive;
 #[cfg(all(not(windows), feature = "capture-stream"))]
+#[cfg_attr(docsrs, doc(cfg(all(not(windows), feature = "capture-stream"))))]
 pub mod selectable;
 
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@
 //! }
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 use std::ffi::{self, CStr};
 use std::fmt;
 
@@ -88,11 +90,13 @@ pub type TstampType = TimestampType;
 mod raw;
 
 #[cfg(windows)]
+#[cfg_attr(docsrs, doc(cfg(windows)))]
 pub mod sendqueue;
 
 #[cfg(feature = "capture-stream")]
 mod stream;
 #[cfg(feature = "capture-stream")]
+#[cfg_attr(docsrs, doc(cfg(feature = "capture-stream")))]
 pub use stream::PacketStream;
 
 /// An error received from pcap

--- a/src/sendqueue/mod.rs
+++ b/src/sendqueue/mod.rs
@@ -1,3 +1,5 @@
+//! Utilities for sending batches of packets.
+
 #[cfg(windows)]
 pub mod windows;
 #[cfg(windows)]

--- a/src/sendqueue/windows.rs
+++ b/src/sendqueue/windows.rs
@@ -14,10 +14,20 @@ use crate::{
     raw, Error,
 };
 
+/// Representation of a batch of packets that can be transferred in a single call using
+/// [`SendQueue::transmit()`].
 pub struct SendQueue(NonNull<raw::pcap_send_queue>);
 
+/// Indicate whether to send packets as quickly as possible or delay the relative amount of time
+/// between packet header timestamps between packet transmissions.
 pub enum SendSync {
+    /// Ignore timestamps; send packets as quickly as possible.
     Off = 0,
+
+    /// Use the time difference between packets to delay between packet transmissions.
+    ///
+    /// # Notes
+    /// The internal (n/win)pcap implementations may implement the delay as a busy-wait loop.
     On = 1,
 }
 


### PR DESCRIPTION
rustdoc/docs.rs support adding cfg/feature labels to generated docs, but it's currently nightly only and put behind a feature gate.  Apparently there are some future goals to make generation of these automatic, but for now it requires adding the entries manually.  docs.rs happens to use nightly to generate docs, so we can make use of that while retaining compatibility with stable rustdoc.

With these changes, `cargo doc` will work the same as it always has, but following the added instructions in the readme will yield labels like the ones (for instance) tokio has: https://docs.rs/tokio/1.42.0/tokio/#modules