### PR TITLE
Add a binding for `pcap_breakloop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - MSRV is now `1.64`.
+- Binding for `pcap_breakloop` added. It can be accessed via the `breakloop_handle` call on Activated captures.
 
 ## [2.3.0] - 2025-07-19
 

--- a/examples/breakloop.rs
+++ b/examples/breakloop.rs
@@ -1,0 +1,36 @@
+use std::{thread, time::Duration};
+
+fn main() {
+    // Get the default device
+    let device = pcap::Device::lookup()
+        .expect("device lookup failed")
+        .expect("no device available");
+    println!("Using device {}", device.name);
+
+    // Setup capture
+    let mut cap = pcap::Capture::from_device(device)
+        .unwrap()
+        .immediate_mode(true)
+        .open()
+        .unwrap();
+    println!("Using device");
+
+    let break_handle = cap.breakloop_handle();
+
+    // Start capture in a separate thread
+    let capture_thread = thread::spawn(move || {
+        while cap.next_packet().is_ok() {
+            println!("got packet!");
+        }
+        println!("capture loop exited");
+    });
+
+    // Send break_handle to a separate thread (e.g. user input, signal handler, etc.)
+    thread::spawn(move || {
+        thread::sleep(Duration::from_secs(1));
+        println!("break loop called!");
+        break_handle.breakloop();
+    });
+
+    capture_thread.join().unwrap();
+}

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -19,7 +19,7 @@ use std::{
 use std::os::unix::io::RawFd;
 
 use crate::{
-    capture::{Activated, Capture, Handle},
+    capture::{Activated, Capture, PcapHandle},
     codec::PacketCodec,
     linktype::Linktype,
     packet::{Packet, PacketHeader},
@@ -264,7 +264,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// ```
     pub fn breakloop_handle(&mut self) -> BreakLoop {
         BreakLoop {
-            handle: Arc::<Handle>::downgrade(&self.handle),
+            handle: Arc::<PcapHandle>::downgrade(&self.handle),
         }
     }
 
@@ -317,7 +317,7 @@ impl<T: Activated + ?Sized> Capture<T> {
 struct HandlerFn<F> {
     func: F,
     panic_payload: Option<Box<dyn Any + Send>>,
-    handle: Arc<Handle>,
+    handle: Arc<PcapHandle>,
 }
 
 impl<F> HandlerFn<F>
@@ -361,7 +361,7 @@ impl<T: Activated> From<Capture<T>> for Capture<dyn Activated> {
 /// See <https://www.tcpdump.org/manpages/pcap_breakloop.3pcap.html> for per-platform caveats about
 /// how breakloop can wake up blocked threads.
 pub struct BreakLoop {
-    handle: Weak<Handle>,
+    handle: Weak<PcapHandle>,
 }
 
 unsafe impl Send for BreakLoop {}

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -12,13 +12,14 @@ use std::{
     path::Path,
     ptr::{self, NonNull},
     slice,
+    sync::{Arc, Weak},
 };
 
 #[cfg(not(windows))]
 use std::os::unix::io::RawFd;
 
 use crate::{
-    capture::{Activated, Capture},
+    capture::{Activated, Capture, Handle},
     codec::PacketCodec,
     linktype::Linktype,
     packet::{Packet, PacketHeader},
@@ -216,23 +217,55 @@ impl<T: Activated + ?Sized> Capture<T> {
             None => -1,
         };
 
-        let mut handler = Handler {
+        let mut handler = HandlerFn {
             func: AssertUnwindSafe(handler),
             panic_payload: None,
-            handle: self.handle,
+            handle: self.handle.clone(),
         };
         let return_code = unsafe {
             raw::pcap_loop(
                 self.handle.as_ptr(),
                 cnt,
-                Handler::<F>::callback,
-                &mut handler as *mut Handler<AssertUnwindSafe<F>> as *mut u8,
+                HandlerFn::<F>::callback,
+                &mut handler as *mut HandlerFn<AssertUnwindSafe<F>> as *mut u8,
             )
         };
         if let Some(e) = handler.panic_payload {
             resume_unwind(e);
         }
         self.check_err(return_code == 0)
+    }
+
+    /// Returns a thread-safe `BreakLoop` handle for calling pcap_breakloop() on an active capture.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// // Using an active capture
+    /// use pcap::Device;
+    ///
+    /// let mut cap = Device::lookup().unwrap().unwrap().open().unwrap();
+    ///
+    /// let break_handle = cap.breakloop_handle();
+    ///
+    /// let capture_thread = std::thread::spawn(move || {
+    ///     while let Ok(packet) = cap.next_packet() {
+    ///         println!("received packet! {:?}", packet);
+    ///     }
+    /// });
+    ///
+    /// // Send break_handle to a separate thread (e.g. user input, signal handler, etc.)
+    /// std::thread::spawn(move || {
+    ///     std::thread::sleep(std::time::Duration::from_secs(1));
+    ///     break_handle.breakloop();
+    /// });
+    ///
+    /// capture_thread.join().unwrap();
+    /// ```
+    pub fn breakloop_handle(&mut self) -> BreakLoop {
+        BreakLoop {
+            handle: Arc::<Handle>::downgrade(&self.handle),
+        }
     }
 
     /// Compiles the string into a filter program using `pcap_compile`.
@@ -281,13 +314,13 @@ impl<T: Activated + ?Sized> Capture<T> {
 // Rust FnMut, which may be a closure with a captured environment. The *only* purpose of this
 // generic parameter is to ensure that in Capture::pcap_loop that we pass the right function
 // pointer and the right data pointer to pcap_loop.
-struct Handler<F> {
+struct HandlerFn<F> {
     func: F,
     panic_payload: Option<Box<dyn Any + Send>>,
-    handle: NonNull<raw::pcap_t>,
+    handle: Arc<Handle>,
 }
 
-impl<F> Handler<F>
+impl<F> HandlerFn<F>
 where
     F: FnMut(Packet),
 {
@@ -319,6 +352,25 @@ where
 impl<T: Activated> From<Capture<T>> for Capture<dyn Activated> {
     fn from(cap: Capture<T>) -> Capture<dyn Activated> {
         unsafe { mem::transmute(cap) }
+    }
+}
+
+/// BreakLoop can safely be sent to other threads such as signal handlers to abort
+/// blocking capture loops such as `Capture::next_packet` and `Capture::for_each`.
+///
+/// See <https://www.tcpdump.org/manpages/pcap_breakloop.3pcap.html> for per-platform caveats about
+/// how breakloop can wake up blocked threads.
+pub struct BreakLoop {
+    handle: Weak<Handle>,
+}
+
+impl BreakLoop {
+    /// Calls `pcap_breakloop` to make the blocking loop of a pcap capture return.
+    /// The call is a no-op if the handle is invalid.
+    pub fn breakloop(&self) {
+        if let Some(handle) = self.handle.upgrade() {
+            unsafe { raw::pcap_breakloop(handle.as_ptr()) };
+        }
     }
 }
 

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -105,8 +105,10 @@ impl Handle {
     }
 }
 
+// `PcapHandle` is safe to Send as it encapsulates the entire lifetime of `raw::pcap_t *`, but it is
+// not safe to Sync as libpcap does not promise thread-safe access to the same `raw::pcap_t *` from
+// multiple threads.
 unsafe impl Send for Handle {}
-unsafe impl Sync for Handle {}
 
 impl Drop for Handle {
     fn drop(&mut self) {
@@ -114,9 +116,6 @@ impl Drop for Handle {
     }
 }
 
-// A Capture is safe to Send as it encapsulates the entire lifetime of `raw::pcap_t *`, but it is
-// not safe to Sync as libpcap does not promise thread-safe access to the same `raw::pcap_t *` from
-// multiple threads.
 unsafe impl<T: State + ?Sized> Send for Capture<T> {}
 
 impl<T: State + ?Sized> From<NonNull<raw::pcap_t>> for Capture<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,9 @@ mod packet;
 #[cfg(not(windows))]
 pub use capture::activated::open_raw_fd;
 pub use capture::{
-    activated::{iterator::PacketIter, BpfInstruction, BpfProgram, Direction, Savefile, Stat},
+    activated::{
+        iterator::PacketIter, BpfInstruction, BpfProgram, BreakLoop, Direction, Savefile, Stat,
+    },
     inactive::TimestampType,
     {Activated, Active, Capture, Dead, Inactive, Offline, Precision, State},
 };


### PR DESCRIPTION
Intent of this PR is to provide a method to stop a blocking capture loop in a multithreaded application so it can handle graceful shutdowns.

Most of the implementation is taken from @FeldrinH's comment [here](https://github.com/rust-pcap/pcap/issues/312#issuecomment-2152944987)

I've tested this works on Linux, however this is untested on Windows.

Fixes #312 