### PR TITLE
Don't automatically link to libpcap

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -197,6 +197,7 @@ fn main() {
 
 fn from_pkg_config() -> Result<pkg_config::Library, pkg_config::Error> {
     let mut config = pkg_config::Config::new();
+    config.cargo_metadata(false);
     // If the user has went out of their way to specify LIBPCAP_VER (even though
     // LIBCAP_LIBDIR wasn't set), respect it. Otherwise fall back to any version
     // as long as it's supported.

--- a/examples/easylisten.rs
+++ b/examples/easylisten.rs
@@ -1,3 +1,6 @@
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     // get the default Device
     let device = pcap::Device::lookup()

--- a/examples/getdevices.rs
+++ b/examples/getdevices.rs
@@ -1,3 +1,6 @@
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     // list all of the devices pcap tells us are available
     for device in pcap::Device::list().expect("device lookup failed") {

--- a/examples/getstatistics.rs
+++ b/examples/getstatistics.rs
@@ -1,3 +1,6 @@
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     // get the default Device
     let device = pcap::Device::lookup()

--- a/examples/helpers/link.rs
+++ b/examples/helpers/link.rs
@@ -1,0 +1,9 @@
+//! Trigger linking against the appropriate library for example binaries.
+
+#[cfg(not(windows))]
+#[link(name = "pcap")]
+extern "C" {}
+
+#[cfg(windows)]
+#[link(name = "wpcap")]
+extern "C" {}

--- a/examples/iterprint.rs
+++ b/examples/iterprint.rs
@@ -2,6 +2,9 @@
 use pcap::{Capture, Device, Packet, PacketCodec, PacketHeader};
 use std::error;
 
+#[path = "helpers/link.rs"]
+mod link;
+
 /// Represents a owned packet
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PacketOwned {

--- a/examples/lendingiterprint.rs
+++ b/examples/lendingiterprint.rs
@@ -4,6 +4,9 @@ use std::error;
 
 use gat_std::gatify;
 
+#[path = "helpers/link.rs"]
+mod link;
+
 #[gatify]
 fn main() -> Result<(), Box<dyn error::Error>> {
     let device = Device::lookup()?.ok_or("no device available")?;

--- a/examples/listenlocalhost.rs
+++ b/examples/listenlocalhost.rs
@@ -1,3 +1,6 @@
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     // listen on the device named "any", which is only available on Linux. This is only for
     // demonstration purposes.

--- a/examples/loop.rs
+++ b/examples/loop.rs
@@ -1,3 +1,6 @@
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     // get the default Device
     let device = pcap::Device::lookup()

--- a/examples/nfbpfcompile.rs
+++ b/examples/nfbpfcompile.rs
@@ -7,6 +7,9 @@ use pcap::{BpfProgram, Capture, Linktype};
 use std::env;
 use std::process;
 
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     let (layertype, prog) = match env::args().len() {
         2 => ("RAW".to_string(), env::args().nth(1).unwrap()),

--- a/examples/savefile.rs
+++ b/examples/savefile.rs
@@ -1,5 +1,8 @@
 use pcap::*;
 
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     {
         // open capture from default device

--- a/examples/savemultiplefiles.rs
+++ b/examples/savemultiplefiles.rs
@@ -1,5 +1,8 @@
 use pcap::Capture;
 
+#[path = "helpers/link.rs"]
+mod link;
+
 fn main() {
     // get the default Device
     let device = pcap::Device::lookup().unwrap().unwrap();

--- a/examples/stdin.rs
+++ b/examples/stdin.rs
@@ -4,6 +4,9 @@
 //!    tcpdump -i en0 -U -w - | cargo run --example stdin
 //!
 
+#[path = "helpers/link.rs"]
+mod link;
+
 #[cfg(not(windows))]
 mod inner {
     use pcap::{Packet, PacketCodec, PacketHeader};

--- a/examples/streamecho.rs
+++ b/examples/streamecho.rs
@@ -6,6 +6,9 @@ use futures::StreamExt;
 use pcap::{Active, Capture, Device, Error, Packet, PacketCodec, PacketStream};
 use std::error;
 
+#[path = "helpers/link.rs"]
+mod link;
+
 // Simple codec that returns owned copies, since the result may not
 // reference the input packet.
 pub struct BoxCodec;

--- a/examples/streamlisten.rs
+++ b/examples/streamlisten.rs
@@ -5,6 +5,9 @@
 use futures::StreamExt;
 use pcap::{Active, Capture, Device, Error, Packet, PacketCodec, PacketStream};
 
+#[path = "helpers/link.rs"]
+mod link;
+
 pub struct SimpleDumpCodec;
 
 impl PacketCodec for SimpleDumpCodec {

--- a/examples/streamlisten_mt.rs
+++ b/examples/streamlisten_mt.rs
@@ -2,6 +2,9 @@ use futures::StreamExt;
 use pcap::{Active, Capture, Device, Error, Packet, PacketCodec, PacketStream};
 use std::error;
 
+#[path = "helpers/link.rs"]
+mod link;
+
 pub struct SimpleDumpCodec;
 
 impl PacketCodec for SimpleDumpCodec {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -260,7 +260,6 @@ pub mod ffi {
 pub mod ffi_unix {
     use super::*;
 
-    #[link(name = "pcap")]
     extern "C" {
         // pub fn pcap_inject(arg1: *mut pcap_t, arg2: *const c_void, arg3: size_t) -> c_int;
         pub fn pcap_set_rfmon(arg1: *mut pcap_t, arg2: c_int) -> c_int;
@@ -287,7 +286,6 @@ pub mod ffi_windows {
 
     pub const WINPCAP_MINTOCOPY_DEFAULT: c_int = 16000;
 
-    #[link(name = "wpcap")]
     extern "C" {
         pub fn pcap_setmintocopy(arg1: *mut pcap_t, arg2: c_int) -> c_int;
         pub fn pcap_getevent(p: *mut pcap_t) -> HANDLE;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -19,6 +19,14 @@ type suseconds_t = libc::suseconds_t;
 #[allow(non_camel_case_types)]
 type suseconds_t = libc::c_long;
 
+#[cfg(not(windows))]
+#[link(name = "pcap")]
+extern "C" {}
+
+#[cfg(windows)]
+#[link(name = "wpcap")]
+extern "C" {}
+
 fn capture_from_test_file(file_name: &str) -> Capture<Offline> {
     let path = Path::new("tests/data/").join(file_name);
     Capture::from_file(path).unwrap()

--- a/tests/tap_tests.rs
+++ b/tests/tap_tests.rs
@@ -33,6 +33,9 @@
 #[cfg(not(windows))]
 mod tests {
 
+    #[link(name = "pcap")]
+    extern "C" {}
+
     use etherparse::{PacketBuilder, PacketHeaders};
     use pcap::Capture;
     use tun_tap::Iface;


### PR DESCRIPTION
pkg-config's default config will output `rustc-link-lib` when it finds a package. However, per this project's readme, linkage is the responsibility of the user, so it seems like merely probing for the version should not change any subsequent build config.

Lines previously present in build.rs output that are now gone:

```
[pcap 2.3.0] cargo:rustc-link-search=native=/usr/lib/x86_64-linux-gnu
[pcap 2.3.0] cargo:rustc-link-lib=pcap
```

Similarly, the `#[link(name = "pcap")]` in `raw` was making dependent binaries automatically link to libpcap.so.

Dependent crates will need to either use a `#[link...` snippet, or specify linkage via [build.rs](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib). That matches my understanding of the readme's linkage policy, and for what it's worth, as a user of the crate I'm fine with that. A downside with this approach is that it's possible to link `libpcap` twice since this crate doesn't specify `link` in its Cargo.toml, but presumably that's something you've already considered as a worthwhile tradeoff to avoid needing to have ever more environment variables to configure linkage.