### PR TITLE
[3.0.0 prep] New pcap_* bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   building against libpcap 1.10.0 or later, since earlier versions do not know the type.
 - Binding for `pcap_dump_ftell64` added. It can be accessed via the `offset` call on `Savefile`
   and reports how many bytes have been written to the file so far. Requires libpcap 1.9.0.
+- Binding for `pcap_init` added. It can be accessed via the `init` call and selects the character
+  encoding libpcap uses for strings. Requires libpcap 1.10.0.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   `pcap_dump_ftell64` is used where it is available, that is from libpcap 1.9.0 on; before that
   the offset comes back as a `long` and the call fails once the file has grown past 2 GB on the
   platforms where that is a 32-bit type.
+- Binding for `pcap_dump_file` added. It can be accessed via the `file` call on `Savefile` and
+  returns the `FILE *` the savefile is being written to. Not available on Windows, where wpcap
+  may be linked against a different C runtime than its caller.
 - Binding for `pcap_init` added. It can be accessed via the `init` call and selects the character
   encoding libpcap uses for strings. Requires libpcap 1.10.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `TimestampType::HostHighPrecUnsynced`, which libpcap 1.10.0 added alongside committing
   `PCAP_TSTAMP_HOST_HIPREC` to being synchronized with the system clock. It is only present when
   building against libpcap 1.10.0 or later, since earlier versions do not know the type.
+- Binding for `pcap_dump_ftell64` added. It can be accessed via the `offset` call on `Savefile`
+  and reports how many bytes have been written to the file so far. Requires libpcap 1.9.0.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 - `TimestampType::HostHighPrecUnsynced`, which libpcap 1.10.0 added alongside committing
   `PCAP_TSTAMP_HOST_HIPREC` to being synchronized with the system clock. It is only present when
   building against libpcap 1.10.0 or later, since earlier versions do not know the type.
-- Binding for `pcap_dump_ftell64` added. It can be accessed via the `offset` call on `Savefile`
-  and reports how many bytes have been written to the file so far. Requires libpcap 1.9.0.
+- Bindings for `pcap_dump_ftell64` and `pcap_dump_ftell` added. They can be accessed via the
+  `offset` call on `Savefile`, which reports how many bytes have been written to the file so far.
+  `pcap_dump_ftell64` is used where it is available, that is from libpcap 1.9.0 on; before that
+  the offset comes back as a `long` and the call fails once the file has grown past 2 GB on the
+  platforms where that is a 32-bit type.
 - Binding for `pcap_init` added. It can be accessed via the `init` call and selects the character
   encoding libpcap uses for strings. Requires libpcap 1.10.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   `PCAP_ERRBUF_SIZE` without regard for character boundaries, so one quoting a long non-ASCII
   path used to arrive as `Error::MalformedError` with the message thrown away. It now arrives as
   `Error::PcapError`. Device and link-layer type names are still rejected when malformed.
+- `Error` has a new `InvalidPath` variant on Windows, which exhaustive matches have to cover.
 - `windows-sys` updated from 0.36 to 0.61. `HANDLE` is a raw pointer there rather than an `isize`,
   which changes the signature of `Capture::get_event` on Windows. A raw pointer is not `Send`, so
   a type of your own that stores the returned `HANDLE` no longer derives `Send` and can no longer
@@ -41,6 +42,14 @@
 
 - `IfFlags::from_bits_unchecked`, which `bitflags` 1 generated. `bitflags` 2 provides
   `IfFlags::from_bits_retain` instead.
+
+### Fixed
+
+- `Capture::from_file`, `Capture::from_file_with_precision`, `Capture::savefile` and
+  `Capture::savefile_append` no longer convert the path with `Path::to_str`. On UN*X the path is
+  handed to libpcap as bytes, so file names that are not valid UTF-8 now work. On Windows such a
+  path returns the new `Error::InvalidPath`, where `savefile` used to panic and `from_file` used
+  to report that a null pointer had been supplied as the file name.
 
 ## [2.5.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Binding for `pcap_dump_file` added. It can be accessed via the `file` call on `Savefile` and
   returns the `FILE *` the savefile is being written to. Not available on Windows, where wpcap
   may be linked against a different C runtime than its caller.
+- Binding for `pcap_snapshot` added. It can be accessed via the `snaplen` call on activated
+  captures and reports the snapshot length in effect, which the `snaplen` call on
+  `Capture<Inactive>` could previously only set. For a `Capture<Offline>` this reports the length
+  the savefile was recorded with.
 - Binding for `pcap_init` added. It can be accessed via the `init` call and selects the character
   encoding libpcap uses for strings. Requires libpcap 1.10.0.
 

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     codec::PacketCodec,
     linktype::Linktype,
     packet::{Packet, PacketHeader},
-    raw,
+    path_to_cstring, raw,
 };
 
 use iterator::PacketIter;
@@ -97,7 +97,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// Create a `Savefile` context for recording captured packets using this `Capture`'s
     /// configurations.
     pub fn savefile<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
-        let name = CString::new(path.as_ref().to_str().unwrap())?;
+        let name = path_to_cstring(path.as_ref())?;
         let handle_opt = NonNull::<raw::pcap_dumper_t>::new(unsafe {
             raw::pcap_dump_open(self.handle.as_ptr(), name.as_ptr())
         });
@@ -135,7 +135,7 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// at the end of the file.
     #[cfg(libpcap_1_7_2)]
     pub fn savefile_append<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
-        let name = CString::new(path.as_ref().to_str().unwrap())?;
+        let name = path_to_cstring(path.as_ref())?;
         let handle_opt = NonNull::<raw::pcap_dumper_t>::new(unsafe {
             raw::pcap_dump_open_append(self.handle.as_ptr(), name.as_ptr())
         });

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -18,6 +18,9 @@ use std::{
 #[cfg(not(windows))]
 use std::os::unix::io::RawFd;
 
+#[cfg(not(windows))]
+use libc::FILE;
+
 use crate::{
     Error,
     capture::{Activated, Capture, PcapHandle},
@@ -489,6 +492,20 @@ impl Savefile {
 
         Ok(offset as u64)
     }
+
+    /// Get the `FILE *` the savefile is being written to
+    ///
+    /// This is not available on Windows, where wpcap may be linked against a different C runtime
+    /// than its caller and the `FILE *` would belong to the wrong one.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the `Savefile` outlives the returned `FILE *` since it is
+    /// closed when the `Savefile` is dropped.
+    #[cfg(not(windows))]
+    pub unsafe fn file(&self) -> *mut FILE {
+        unsafe { raw::pcap_dump_file(self.handle.as_ptr()) }
+    }
 }
 
 impl From<NonNull<raw::pcap_dumper_t>> for Savefile {
@@ -947,6 +964,19 @@ mod tests {
 
         let result = savefile.offset();
         assert!(result.is_err());
+
+        #[cfg(not(windows))]
+        {
+            let mut dummy: isize = 999;
+            let file = &mut dummy as *mut isize as *mut FILE;
+
+            let ctx = raw::pcap_dump_file_context();
+            ctx.expect()
+                .withf_st(move |arg1| *arg1 == pcap_dumper)
+                .return_once_st(move |_| file);
+
+            assert_eq!(unsafe { savefile.file() }, file);
+        }
     }
 
     #[test]

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -473,9 +473,16 @@ impl Savefile {
 
     /// Get the current offset of the savefile, that is the number of bytes written so far,
     /// including any that are still buffered
-    #[cfg(libpcap_1_9_0)]
     pub fn offset(&self) -> Result<u64, Error> {
+        // Prior to 1.9.0 when `pcap_dump_ftell64` was introduced, the offset was only reported as
+        // a `long`. Where that is a 32-bit type, as it is on Windows, the call fails once the
+        // savefile has grown past 2 GB.
+        #[cfg(libpcap_1_9_0)]
         let offset = unsafe { raw::pcap_dump_ftell64(self.handle.as_ptr()) };
+
+        #[cfg(not(libpcap_1_9_0))]
+        let offset = unsafe { raw::pcap_dump_ftell(self.handle.as_ptr()) };
+
         if offset < 0 {
             return Err(Error::ErrnoError(errno::errno()));
         }
@@ -861,6 +868,36 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(libpcap_1_9_0)]
+    struct DumpFtellExpect(raw::__pcap_dump_ftell64::Context);
+
+    #[cfg(not(libpcap_1_9_0))]
+    struct DumpFtellExpect(raw::__pcap_dump_ftell::Context);
+
+    fn dump_ftell_expect(pcap_dumper: *mut raw::pcap_dumper_t, offset: i64) -> DumpFtellExpect {
+        // Lock must be acquired by caller.
+        assert!(RAWMTX.try_lock().is_err());
+
+        #[cfg(libpcap_1_9_0)]
+        {
+            let ctx = raw::pcap_dump_ftell64_context();
+            ctx.checkpoint();
+            ctx.expect()
+                .withf_st(move |arg1| *arg1 == pcap_dumper)
+                .return_once(move |_| offset);
+            DumpFtellExpect(ctx)
+        }
+        #[cfg(not(libpcap_1_9_0))]
+        {
+            let ctx = raw::pcap_dump_ftell_context();
+            ctx.checkpoint();
+            ctx.expect()
+                .withf_st(move |arg1| *arg1 == pcap_dumper)
+                .return_once(move |_| offset as _);
+            DumpFtellExpect(ctx)
+        }
+    }
+
     #[test]
     fn test_savefile_ops() {
         let _m = RAWMTX.lock();
@@ -901,25 +938,15 @@ mod tests {
         let result = savefile.flush();
         assert!(result.is_err());
 
-        #[cfg(libpcap_1_9_0)]
-        {
-            let ctx = raw::pcap_dump_ftell64_context();
-            ctx.expect()
-                .withf_st(move |arg1| *arg1 == pcap_dumper)
-                .return_once(|_| 6144);
+        let _ctx = dump_ftell_expect(pcap_dumper, 6144);
 
-            let result = savefile.offset();
-            assert_eq!(result.unwrap(), 6144);
+        let result = savefile.offset();
+        assert_eq!(result.unwrap(), 6144);
 
-            let ctx = raw::pcap_dump_ftell64_context();
-            ctx.checkpoint();
-            ctx.expect()
-                .withf_st(move |arg1| *arg1 == pcap_dumper)
-                .return_once(|_| -1);
+        let _ctx = dump_ftell_expect(pcap_dumper, -1);
 
-            let result = savefile.offset();
-            assert!(result.is_err());
-        }
+        let result = savefile.offset();
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -470,6 +470,18 @@ impl Savefile {
 
         Ok(())
     }
+
+    /// Get the current offset of the savefile, that is the number of bytes written so far,
+    /// including any that are still buffered
+    #[cfg(libpcap_1_9_0)]
+    pub fn offset(&self) -> Result<u64, Error> {
+        let offset = unsafe { raw::pcap_dump_ftell64(self.handle.as_ptr()) };
+        if offset < 0 {
+            return Err(Error::ErrnoError(errno::errno()));
+        }
+
+        Ok(offset as u64)
+    }
 }
 
 impl From<NonNull<raw::pcap_dumper_t>> for Savefile {
@@ -888,6 +900,26 @@ mod tests {
 
         let result = savefile.flush();
         assert!(result.is_err());
+
+        #[cfg(libpcap_1_9_0)]
+        {
+            let ctx = raw::pcap_dump_ftell64_context();
+            ctx.expect()
+                .withf_st(move |arg1| *arg1 == pcap_dumper)
+                .return_once(|_| 6144);
+
+            let result = savefile.offset();
+            assert_eq!(result.unwrap(), 6144);
+
+            let ctx = raw::pcap_dump_ftell64_context();
+            ctx.checkpoint();
+            ctx.expect()
+                .withf_st(move |arg1| *arg1 == pcap_dumper)
+                .return_once(|_| -1);
+
+            let result = savefile.offset();
+            assert!(result.is_err());
+        }
     }
 
     #[test]

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -97,6 +97,15 @@ impl<T: Activated + ?Sized> Capture<T> {
         unsafe { Linktype(raw::pcap_datalink(self.handle.as_ptr())) }
     }
 
+    /// Get the snapshot length, that is the maximum number of bytes captured from each packet.
+    ///
+    /// For a `Capture<Offline>` this is the length the savefile was recorded with, except that a
+    /// header claiming zero, or a length too large for an `i32`, is replaced with the largest
+    /// length the link-layer type can produce.
+    pub fn snaplen(&self) -> i32 {
+        unsafe { raw::pcap_snapshot(self.handle.as_ptr()) }
+    }
+
     /// Create a `Savefile` context for recording captured packets using this `Capture`'s
     /// configurations.
     pub fn savefile<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
@@ -739,6 +748,24 @@ mod tests {
 
         let linktype = capture.get_datalink();
         assert_eq!(linktype, Linktype::ETHERNET);
+    }
+
+    #[test]
+    fn test_snaplen() {
+        let _m = RAWMTX.lock();
+
+        let mut value: isize = 777;
+        let pcap = as_pcap_t(&mut value);
+
+        let test_capture = test_capture::<Active>(pcap);
+        let capture: Capture<dyn Activated> = test_capture.capture.into();
+
+        let ctx = raw::pcap_snapshot_context();
+        ctx.expect()
+            .withf_st(move |arg1| *arg1 == pcap)
+            .return_once(|_| 65535);
+
+        assert_eq!(capture.snaplen(), 65535);
     }
 
     #[test]

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -108,6 +108,10 @@ impl<T: Activated + ?Sized> Capture<T> {
 
     /// Create a `Savefile` context for recording captured packets using this `Capture`'s
     /// configurations.
+    ///
+    /// On Windows a path outside ASCII needs `init(CharEncoding::Utf8)` first. The path always
+    /// reaches libpcap as UTF-8, but until that call libpcap reads it in the local code page,
+    /// which on most systems is not UTF-8: the name gets mangled and the file lands elsewhere.
     pub fn savefile<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
         let name = path_to_cstring(path.as_ref())?;
         let handle_opt = NonNull::<raw::pcap_dumper_t>::new(unsafe {
@@ -145,6 +149,10 @@ impl<T: Activated + ?Sized> Capture<T> {
     /// byte order as the host opening the file, and has the same timestamp precision,
     /// link-layer header type,  and  snapshot length as p, it will write new packets
     /// at the end of the file.
+    ///
+    /// On Windows a path outside ASCII needs `init(CharEncoding::Utf8)` first. The path always
+    /// reaches libpcap as UTF-8, but until that call libpcap reads it in the local code page,
+    /// which on most systems is not UTF-8: the name gets mangled and the file lands elsewhere.
     #[cfg(libpcap_1_7_2)]
     pub fn savefile_append<P: AsRef<Path>>(&self, path: P) -> Result<Savefile, Error> {
         let name = path_to_cstring(path.as_ref())?;

--- a/src/capture/activated/offline.rs
+++ b/src/capture/activated/offline.rs
@@ -6,7 +6,7 @@ use std::os::unix::io::RawFd;
 use crate::{
     Error,
     capture::{Capture, Offline},
-    raw,
+    path_to_cstring, raw,
 };
 
 #[cfg(libpcap_1_5_0)]
@@ -18,7 +18,8 @@ use crate::capture::activated::open_raw_fd;
 impl Capture<Offline> {
     /// Opens an offline capture handle from a pcap dump file, given a path.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Capture<Offline>, Error> {
-        Capture::new_raw(path.as_ref().to_str(), |path, err| unsafe {
+        let path = path_to_cstring(path.as_ref())?;
+        Capture::new_raw(Some(path), |path, err| unsafe {
             raw::pcap_open_offline(path, err)
         })
     }
@@ -30,7 +31,8 @@ impl Capture<Offline> {
         path: P,
         precision: Precision,
     ) -> Result<Capture<Offline>, Error> {
-        Capture::new_raw(path.as_ref().to_str(), |path, err| unsafe {
+        let path = path_to_cstring(path.as_ref())?;
+        Capture::new_raw(Some(path), |path, err| unsafe {
             raw::pcap_open_offline_with_tstamp_precision(path, precision as _, err)
         })
     }

--- a/src/capture/activated/offline.rs
+++ b/src/capture/activated/offline.rs
@@ -17,6 +17,10 @@ use crate::capture::activated::open_raw_fd;
 
 impl Capture<Offline> {
     /// Opens an offline capture handle from a pcap dump file, given a path.
+    ///
+    /// On Windows a path outside ASCII needs `init(CharEncoding::Utf8)` first. The path always
+    /// reaches libpcap as UTF-8, but until that call libpcap reads it in the local code page,
+    /// which on most systems is not UTF-8: the name gets mangled and the file is not found.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Capture<Offline>, Error> {
         let path = path_to_cstring(path.as_ref())?;
         Capture::new_raw(Some(path), |path, err| unsafe {
@@ -26,6 +30,10 @@ impl Capture<Offline> {
 
     /// Opens an offline capture handle from a pcap dump file, given a path.
     /// Takes an additional precision argument specifying the timestamp precision desired.
+    ///
+    /// On Windows a path outside ASCII needs `init(CharEncoding::Utf8)` first. The path always
+    /// reaches libpcap as UTF-8, but until that call libpcap reads it in the local code page,
+    /// which on most systems is not UTF-8: the name gets mangled and the file is not found.
     #[cfg(libpcap_1_5_0)]
     pub fn from_file_with_precision<P: AsRef<Path>>(
         path: P,

--- a/src/capture/inactive.rs
+++ b/src/capture/inactive.rs
@@ -1,3 +1,4 @@
+use std::ffi::CString;
 use std::mem;
 
 use crate::{
@@ -33,7 +34,8 @@ impl Capture<Inactive> {
     /// ```
     pub fn from_device<D: Into<Device>>(device: D) -> Result<Capture<Inactive>, Error> {
         let device: Device = device.into();
-        Capture::new_raw(Some(&device.name), |name, err| unsafe {
+        let name = CString::new(device.name)?;
+        Capture::new_raw(Some(name), |name, err| unsafe {
             raw::pcap_create(name, err)
         })
     }

--- a/src/capture/mod.rs
+++ b/src/capture/mod.rs
@@ -132,17 +132,14 @@ impl<T: State + ?Sized> From<NonNull<raw::pcap_t>> for Capture<T> {
 }
 
 impl<T: State + ?Sized> Capture<T> {
-    fn new_raw<F>(path: Option<&str>, func: F) -> Result<Capture<T>, Error>
+    fn new_raw<F>(path: Option<CString>, func: F) -> Result<Capture<T>, Error>
     where
         F: FnOnce(*const libc::c_char, *mut libc::c_char) -> *mut raw::pcap_t,
     {
         Error::with_errbuf(|err| {
             let handle = match path {
                 None => func(ptr::null(), err),
-                Some(path) => {
-                    let path = CString::new(path)?;
-                    func(path.as_ptr(), err)
-                }
+                Some(path) => func(path.as_ptr(), err),
             };
             Ok(Capture::from(
                 NonNull::<raw::pcap_t>::new(handle).ok_or_else(|| unsafe { Error::new(err) })?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,9 @@ pub enum CharEncoding {
 ///
 /// This is optional, but it has to come before any other libpcap call, and a second call asking
 /// for a different encoding fails. Without it strings are in the local character encoding.
+///
+/// On Windows this is what makes a path outside ASCII work, since the local code page is
+/// usually not UTF-8.
 #[cfg(libpcap_1_10_0)]
 pub fn init(encoding: CharEncoding) -> Result<(), Error> {
     Error::with_errbuf(|err| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use std::ffi::{self, CStr};
+use std::ffi::{self, CStr, CString};
 use std::fmt;
+use std::path::Path;
 
 use self::Error::*;
 
@@ -131,6 +132,9 @@ pub enum Error {
     #[cfg(not(windows))]
     /// An invalid raw file descriptor was provided
     InvalidRawFd,
+    #[cfg(windows)]
+    /// A path that libpcap cannot be given because it is not valid UTF-8
+    InvalidPath,
     /// Errno error
     ErrnoError(errno::Errno),
     /// Buffer size overflows capacity
@@ -172,6 +176,25 @@ unsafe fn cstr_to_string(ptr: *const libc::c_char) -> Result<Option<String>, Err
     Ok(string)
 }
 
+fn path_to_cstring(path: &Path) -> Result<CString, Error> {
+    #[cfg(not(windows))]
+    let bytes = {
+        use std::os::unix::ffi::OsStrExt;
+        path.as_os_str().as_bytes()
+    };
+    // libpcap has no entry points taking wide strings. It reads the path in the local code page,
+    // or in UTF-8 once pcap_init has been asked for that, so give it the UTF-8 form. A path that
+    // is not valid UTF-8 holds an unpaired surrogate, which has no form libpcap would accept.
+    #[cfg(windows)]
+    let bytes = path
+        .as_os_str()
+        .to_str()
+        .ok_or(Error::InvalidPath)?
+        .as_bytes();
+
+    Ok(CString::new(bytes)?)
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -189,6 +212,8 @@ impl fmt::Display for Error {
             IoError(ref e) => write!(f, "io error occurred: {e:?}"),
             #[cfg(not(windows))]
             InvalidRawFd => write!(f, "invalid raw file descriptor provided"),
+            #[cfg(windows)]
+            InvalidPath => write!(f, "invalid path (not valid UTF-8)"),
             ErrnoError(ref e) => write!(f, "libpcap os errno: {e}"),
             BufferOverflow => write!(f, "buffer size too large"),
         }
@@ -213,6 +238,8 @@ impl std::error::Error for Error {
             IoError(..) => "io error occurred",
             #[cfg(not(windows))]
             InvalidRawFd => "invalid raw file descriptor provided",
+            #[cfg(windows)]
+            InvalidPath => "invalid path (not valid UTF-8)",
             ErrnoError(..) => "internal error, providing errno",
             BufferOverflow => "buffer size too large",
         }
@@ -331,6 +358,8 @@ mod tests {
         errors.push(io::Error::new(io::ErrorKind::Interrupted, "error").into());
         #[cfg(not(windows))]
         errors.push(Error::InvalidRawFd);
+        #[cfg(windows)]
+        errors.push(Error::InvalidPath);
         errors.push(Error::ErrnoError(errno::Errno(125)));
         errors.push(Error::BufferOverflow);
 
@@ -350,6 +379,18 @@ mod tests {
             packet_header_size(),
             std::mem::size_of::<raw::pcap_pkthdr>()
         );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_path_to_cstring_not_utf8() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+
+        // An unpaired surrogate, which a Windows path may hold and UTF-8 cannot express.
+        let name = OsString::from_wide(&[0xd800]);
+        let result = path_to_cstring(Path::new(&name));
+        assert_eq!(result.unwrap_err(), Error::InvalidPath);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,10 +258,40 @@ pub const fn packet_header_size() -> usize {
     std::mem::size_of::<raw::pcap_pkthdr>()
 }
 
+#[cfg(libpcap_1_10_0)]
+#[repr(u32)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+/// The character encoding libpcap uses for strings. Use with `init`.
+pub enum CharEncoding {
+    /// Strings are in the local character encoding. On UN*X that is taken to be UTF-8, on Windows
+    /// it is the local ANSI code page. This is the default.
+    Local = raw::PCAP_CHAR_ENC_LOCAL,
+    /// Strings are in UTF-8.
+    Utf8 = raw::PCAP_CHAR_ENC_UTF_8,
+}
+
+/// Initialize the library, choosing the character encoding it uses for the strings it is given
+/// and the strings it returns.
+///
+/// This is optional, but it has to come before any other libpcap call, and a second call asking
+/// for a different encoding fails. Without it strings are in the local character encoding.
+#[cfg(libpcap_1_10_0)]
+pub fn init(encoding: CharEncoding) -> Result<(), Error> {
+    Error::with_errbuf(|err| {
+        if unsafe { raw::pcap_init(encoding as _, err) } != 0 {
+            return Err(unsafe { Error::new(err) });
+        }
+        Ok(())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error as StdError;
     use std::{ffi::CString, io};
+
+    #[cfg(libpcap_1_10_0)]
+    use crate::raw::testmod::RAWMTX;
 
     use super::*;
 
@@ -320,5 +350,28 @@ mod tests {
             packet_header_size(),
             std::mem::size_of::<raw::pcap_pkthdr>()
         );
+    }
+
+    #[test]
+    #[cfg(libpcap_1_10_0)]
+    fn test_init() {
+        let _m = RAWMTX.lock();
+
+        let ctx = raw::pcap_init_context();
+        ctx.expect()
+            .withf_st(|arg1, _| *arg1 == raw::PCAP_CHAR_ENC_UTF_8)
+            .return_once(|_, _| 0);
+
+        let result = init(CharEncoding::Utf8);
+        assert!(result.is_ok());
+
+        let ctx = raw::pcap_init_context();
+        ctx.checkpoint();
+        ctx.expect()
+            .withf_st(|arg1, _| *arg1 == raw::PCAP_CHAR_ENC_LOCAL)
+            .return_once(|_, _| -1);
+
+        let result = init(CharEncoding::Local);
+        assert!(result.is_err());
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, sockaddr, timeval};
+use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_ushort, sockaddr, timeval};
 
 #[cfg(test)]
 use mockall::automock;
@@ -191,7 +191,7 @@ pub mod ffi {
         pub fn pcap_fileno(arg1: *mut pcap_t) -> c_int;
         pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
         // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
-        // pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> c_long;
+        pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> c_long;
         pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int;
         pub fn pcap_dump_close(arg1: *mut pcap_dumper_t);
         pub fn pcap_dump(arg1: *mut c_uchar, arg2: *const pcap_pkthdr, arg3: *const c_uchar);

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -235,7 +235,7 @@ pub mod ffi {
     unsafe extern "C" {
         // pcap_bufsize
         // pcap_createsrcstr
-        // pcap_dump_ftell64
+        pub fn pcap_dump_ftell64(arg1: *mut pcap_dumper_t) -> i64;
         // pcap_findalldevs_ex
         // pcap_get_required_select_timeout
         // pcap_open

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -17,6 +17,9 @@ pub const PCAP_IF_CONNECTION_STATUS_CONNECTED: u32 = 0x00000010;
 pub const PCAP_IF_CONNECTION_STATUS_DISCONNECTED: u32 = 0x00000020;
 pub const PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE: u32 = 0x00000030;
 
+pub const PCAP_CHAR_ENC_LOCAL: u32 = 0x00000000;
+pub const PCAP_CHAR_ENC_UTF_8: u32 = 0x00000001;
+
 pub const PCAP_WARNING_TSTAMP_TYPE_NOTSUP: c_int = 3;
 pub const PCAP_ERROR_TSTAMP_PRECISION_NOTSUP: c_int = -12;
 
@@ -255,7 +258,7 @@ pub mod ffi {
 
     #[cfg(libpcap_1_10_0)]
     unsafe extern "C" {
-        // pcap_init
+        pub fn pcap_init(arg1: c_uint, arg2: *mut c_char) -> c_int;
         // pcap_remoteact_accept_ex
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -183,7 +183,7 @@ pub mod ffi {
         pub fn pcap_datalink_name_to_val(arg1: *const c_char) -> c_int;
         pub fn pcap_datalink_val_to_name(arg1: c_int) -> *const c_char;
         pub fn pcap_datalink_val_to_description(arg1: c_int) -> *const c_char;
-        // pub fn pcap_snapshot(arg1: *mut pcap_t) -> c_int;
+        pub fn pcap_snapshot(arg1: *mut pcap_t) -> c_int;
         // pub fn pcap_is_swapped(arg1: *mut pcap_t) -> c_int;
         pub fn pcap_major_version(arg1: *mut pcap_t) -> c_int;
         pub fn pcap_minor_version(arg1: *mut pcap_t) -> c_int;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -190,7 +190,6 @@ pub mod ffi {
         // pub fn pcap_file(arg1: *mut pcap_t) -> *mut FILE;
         pub fn pcap_fileno(arg1: *mut pcap_t) -> c_int;
         pub fn pcap_dump_open(arg1: *mut pcap_t, arg2: *const c_char) -> *mut pcap_dumper_t;
-        // pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
         pub fn pcap_dump_ftell(arg1: *mut pcap_dumper_t) -> c_long;
         pub fn pcap_dump_flush(arg1: *mut pcap_dumper_t) -> c_int;
         pub fn pcap_dump_close(arg1: *mut pcap_dumper_t);
@@ -280,6 +279,10 @@ pub mod ffi_unix {
         // the OS handle out of the FILE * and call pcap_hopen_offline()/pcap_dump_hopen().
         pub fn pcap_fopen_offline(arg1: *mut FILE, arg2: *mut c_char) -> *mut pcap_t;
         pub fn pcap_dump_fopen(arg1: *mut pcap_t, fp: *mut FILE) -> *mut pcap_dumper_t;
+        // wpcap does export this one, but the FILE * it hands back belongs to the C runtime
+        // wpcap was linked against, which is not necessarily the caller's, so it is no more
+        // usable on Windows than the entry points above.
+        pub fn pcap_dump_file(arg1: *mut pcap_dumper_t) -> *mut FILE;
     }
 
     #[cfg(libpcap_1_5_0)]

--- a/tests/capture/activated/mod.rs
+++ b/tests/capture/activated/mod.rs
@@ -141,6 +141,24 @@ fn capture_dead_savefile_file() {
 }
 
 #[test]
+fn capture_offline_snaplen() {
+    for (file_name, snaplen) in [
+        ("packet_snaplen_20.pcap", 20),
+        ("packet_snaplen_65535.pcap", 65535),
+    ] {
+        let capture = capture_from_test_file(file_name);
+        assert_eq!(capture.snaplen(), snaplen, "{file_name}");
+    }
+}
+
+#[test]
+fn capture_dead_snaplen() {
+    // `Capture::dead` opens the handle with a snaplen of 65535.
+    let cap = Capture::dead(Linktype(1)).unwrap();
+    assert_eq!(cap.snaplen(), 65535);
+}
+
+#[test]
 fn test_linktype() {
     let capture = capture_from_test_file("packet_snaplen_65535.pcap");
     let linktype = capture.get_datalink();

--- a/tests/capture/activated/mod.rs
+++ b/tests/capture/activated/mod.rs
@@ -36,6 +36,33 @@ fn capture_dead_savefile() {
     packets.verify(&mut cap);
 }
 
+// APFS validates file names as UTF-8 and rejects the rest with EILSEQ, so a name that is not
+// valid UTF-8 only round trips where a file name is an opaque byte string.
+#[test]
+#[cfg(not(any(windows, target_os = "macos")))]
+fn capture_dead_savefile_non_utf8_name() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    let mut packets = Packets::new();
+    packets.push(1460408319, 1234, 1, 1, &[1]);
+    packets.push(1460408320, 4321, 1, 1, &[2]);
+
+    let dir = TempDir::new().unwrap();
+    // A UN*X path is a byte string, it does not have to be valid UTF-8.
+    let tmpfile = dir.path().join(OsStr::from_bytes(b"\xe9capture.pcap"));
+
+    let cap = Capture::dead(Linktype(1)).unwrap();
+    let mut save = cap.savefile(&tmpfile).unwrap();
+    packets.foreach(|p| save.write(p));
+    drop(save);
+
+    assert!(tmpfile.exists());
+
+    let mut cap = Capture::from_file(&tmpfile).unwrap();
+    packets.verify(&mut cap);
+}
+
 #[test]
 #[cfg(libpcap_1_7_2)]
 fn capture_dead_savefile_append() {

--- a/tests/capture/activated/mod.rs
+++ b/tests/capture/activated/mod.rs
@@ -92,7 +92,6 @@ fn capture_dead_savefile_append() {
 }
 
 #[test]
-#[cfg(libpcap_1_9_0)]
 fn capture_dead_savefile_offset() {
     let mut packets = Packets::new();
     packets.push(1460408319, 1234, 1, 1, &[1]);

--- a/tests/capture/activated/mod.rs
+++ b/tests/capture/activated/mod.rs
@@ -118,6 +118,29 @@ fn capture_dead_savefile_offset() {
 }
 
 #[test]
+#[cfg(not(windows))]
+fn capture_dead_savefile_file() {
+    let dir = TempDir::new().unwrap();
+    let tmpfile = dir.path().join("test.pcap");
+
+    let cap = Capture::dead(Linktype(1)).unwrap();
+    let mut save = cap.savefile(&tmpfile).unwrap();
+    save.flush().unwrap();
+
+    // SAFETY: the FILE * is not used past the end of this test, where `save` is still alive.
+    let fd = unsafe { libc::fileno(save.file()) };
+    assert!(fd >= 0);
+
+    // The stream the header was just flushed to is the one the savefile was opened on.
+    let mut stat = std::mem::MaybeUninit::<libc::stat>::uninit();
+    assert_eq!(unsafe { libc::fstat(fd, stat.as_mut_ptr()) }, 0);
+    assert_eq!(
+        unsafe { stat.assume_init() }.st_size as u64,
+        save.offset().unwrap()
+    );
+}
+
+#[test]
 fn test_linktype() {
     let capture = capture_from_test_file("packet_snaplen_65535.pcap");
     let linktype = capture.get_datalink();

--- a/tests/capture/activated/mod.rs
+++ b/tests/capture/activated/mod.rs
@@ -65,6 +65,33 @@ fn capture_dead_savefile_append() {
 }
 
 #[test]
+#[cfg(libpcap_1_9_0)]
+fn capture_dead_savefile_offset() {
+    let mut packets = Packets::new();
+    packets.push(1460408319, 1234, 1, 1, &[1]);
+    packets.push(1460408320, 4321, 1, 1, &[2]);
+
+    let dir = TempDir::new().unwrap();
+    let tmpfile = dir.path().join("test.pcap");
+
+    let cap = Capture::dead(Linktype(1)).unwrap();
+    let mut save = cap.savefile(&tmpfile).unwrap();
+
+    // The file header has been written, the packets have not.
+    let header_only = save.offset().unwrap();
+    assert!(header_only > 0);
+
+    packets.foreach(|p| save.write(p));
+    let with_packets = save.offset().unwrap();
+    assert!(with_packets > header_only);
+
+    drop(save);
+
+    let written = std::fs::metadata(&tmpfile).unwrap().len();
+    assert_eq!(with_packets, written);
+}
+
+#[test]
 fn test_linktype() {
     let capture = capture_from_test_file("packet_snaplen_65535.pcap");
     let linktype = capture.get_datalink();

--- a/tests/charenc.rs
+++ b/tests/charenc.rs
@@ -1,0 +1,55 @@
+//! Capture file paths that are not plain ASCII.
+//!
+//! On Windows libpcap reads the path in the local code page unless pcap_init has been asked for
+//! UTF-8, and that choice is made once for the whole process and cannot be taken back. These
+//! tests therefore need a test binary to themselves.
+#![cfg(any(not(windows), libpcap_1_10_0))]
+
+use std::fs;
+
+use tempfile::TempDir;
+
+use pcap::{Capture, Linktype};
+
+/// "capture", in four scripts. libpcap converts the path with one call that does not care which
+/// script it is looking at, so these cover the encoding widths rather than the languages.
+const NAMES: &[&str] = &[
+    "захват",     // Russian, two-byte
+    "捕获",       // Chinese, three-byte
+    "कैप्चर",       // Hindi, three-byte with combining marks
+    "𝄞capture🎯", // Astral plane, four-byte
+];
+
+#[cfg(not(windows))]
+fn use_utf8_paths() {}
+
+#[cfg(windows)]
+fn use_utf8_paths() {
+    pcap::init(pcap::CharEncoding::Utf8).unwrap();
+}
+
+#[test]
+fn savefile_round_trip_non_ascii_paths() {
+    use_utf8_paths();
+
+    let dir = TempDir::new().unwrap();
+
+    for name in NAMES {
+        // The name is used for a directory as well as for the file, since libpcap converts the
+        // whole path and a directory component has to work just as a file name does.
+        let subdir = dir.path().join(name);
+        fs::create_dir(&subdir).unwrap();
+        let tmpfile = subdir.join(format!("{name}.pcap"));
+
+        let cap = Capture::dead(Linktype(1)).unwrap();
+        let save = cap.savefile(&tmpfile).unwrap();
+        drop(save);
+
+        assert!(
+            tmpfile.exists(),
+            "{name} was not written where it was asked for"
+        );
+
+        Capture::from_file(&tmpfile).unwrap();
+    }
+}


### PR DESCRIPTION
- pcap_init
- pcap_dump_ftell
- pcap_dump_ftell64
- pcap_dump_file
- pcap_snapshot

---

`pcap_init` fixes #383 and supersedes #384.

Must be merged after #400, and a rebase will be done then.