### PR TITLE
[3.0.0 prep] Stop Savefile::write reading past the packet data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
   handed to libpcap as bytes, so file names that are not valid UTF-8 now work. On Windows such a
   path returns the new `Error::InvalidPath`, where `savefile` used to panic and `from_file` used
   to report that a null pointer had been supplied as the file name.
+- `Savefile::write` no longer reads past the end of the packet data.
 
 ## [2.5.0] - 2026-08-15
 

--- a/src/capture/activated/mod.rs
+++ b/src/capture/activated/mod.rs
@@ -472,13 +472,22 @@ unsafe impl Send for Savefile {}
 
 impl Savefile {
     /// Write a packet to a capture file
+    ///
+    /// At most `packet.data.len()` bytes are written. A larger `caplen` in the header is capped
+    /// to that, and `len` is raised to the number of bytes written if it is smaller.
     pub fn write(&mut self, packet: &Packet<'_>) {
+        let caplen = packet
+            .header
+            .caplen
+            .min(u32::try_from(packet.data.len()).unwrap_or(u32::MAX));
+        let header = raw::pcap_pkthdr {
+            ts: packet.header.ts,
+            caplen,
+            len: packet.header.len.max(caplen),
+        };
+
         unsafe {
-            raw::pcap_dump(
-                self.handle.as_ptr() as _,
-                &*(packet.header as *const PacketHeader as *const raw::pcap_pkthdr),
-                packet.data.as_ptr(),
-            );
+            raw::pcap_dump(self.handle.as_ptr() as _, &header, packet.data.as_ptr());
         }
     }
 
@@ -654,7 +663,7 @@ mod tests {
     use crate::{
         capture::{
             Active, Capture, Offline,
-            activated::testmod::{PACKET, next_ex_expect},
+            activated::testmod::{DATA, PACKET, TS, next_ex_expect},
             testmod::test_capture,
         },
         raw::testmod::{RAWMTX, as_pcap_dumper_t, as_pcap_t, geterr_expect},
@@ -1012,6 +1021,47 @@ mod tests {
 
             assert_eq!(unsafe { savefile.file() }, file);
         }
+    }
+
+    // A caplen past the end of the data, and a len shorter than what is written, are covered by
+    // the savefile tests. What is left to check here is that a truncated packet, which is what a
+    // caplen within the data means, still goes through with the header it came with.
+    #[test]
+    fn test_savefile_write_truncated() {
+        let _m = RAWMTX.lock();
+
+        let mut value: isize = 888;
+        let pcap_dumper = as_pcap_dumper_t(&mut value);
+
+        let ctx = raw::pcap_dump_close_context();
+        ctx.expect()
+            .withf_st(move |arg1| *arg1 == pcap_dumper)
+            .return_once(|_| {});
+
+        let mut savefile = Savefile {
+            handle: NonNull::new(pcap_dumper).unwrap(),
+        };
+
+        let header = PacketHeader {
+            ts: TS,
+            caplen: 2,
+            len: 60,
+        };
+
+        let ctx = raw::pcap_dump_context();
+        ctx.expect()
+            .withf_st(move |arg1, arg2, arg3| {
+                let header = unsafe { &**arg2 };
+                *arg1 == pcap_dumper as _
+                    && *arg3 == DATA.as_ptr()
+                    && header.caplen == 2
+                    && header.len == 60
+                    && header.ts.tv_sec == TS.tv_sec
+                    && header.ts.tv_usec == TS.tv_usec
+            })
+            .return_once(|_, _, _| {});
+
+        savefile.write(&Packet::new(&header, &DATA));
     }
 
     #[test]

--- a/tests/capture/activated/mod.rs
+++ b/tests/capture/activated/mod.rs
@@ -64,6 +64,36 @@ fn capture_dead_savefile_non_utf8_name() {
 }
 
 #[test]
+fn capture_dead_savefile_bad_caplen() {
+    let data = [1, 2, 3, 4];
+
+    let mut packets = Packets::new();
+    packets.push(1460408319, 1234, 16384, 16384, &data); // caplen past the end of the data
+    packets.push(1460408320, 4321, 16384, 1, &data); // len shorter than what is written
+
+    let mut written = Packets::new();
+    written.push(1460408319, 1234, 4, 16384, &data);
+    written.push(1460408320, 4321, 4, 4, &data);
+
+    let dir = TempDir::new().unwrap();
+    let tmpfile = dir.path().join("test.pcap");
+
+    let cap = Capture::dead(Linktype(1)).unwrap();
+    let mut save = cap.savefile(&tmpfile).unwrap();
+    packets.foreach(|p| save.write(p));
+    drop(save);
+
+    // A 24-byte file header, then a 16-byte record header and 4 bytes of data per packet.
+    assert_eq!(
+        std::fs::metadata(&tmpfile).unwrap().len(),
+        24 + 2 * (16 + 4)
+    );
+
+    let mut cap = Capture::from_file(&tmpfile).unwrap();
+    written.verify(&mut cap);
+}
+
+#[test]
 #[cfg(libpcap_1_7_2)]
 fn capture_dead_savefile_append() {
     let mut packets1 = Packets::new();


### PR DESCRIPTION
`Savefile::write` no longer reads past the end of the packet data. `caplen` is now capped at the length of the data, and `len` raised to match when it is smaller.

---

Discovered by Rust ASan.